### PR TITLE
docker-compose v2 format example

### DIFF
--- a/docker-compose-v2.yml
+++ b/docker-compose-v2.yml
@@ -1,0 +1,52 @@
+version: '2'
+services:
+  redis:
+    image: redis
+    restart: always
+    volumes:
+     - redis:/data 
+  postgres:
+    image: postgres
+    restart: always
+    volumes:
+      - postgresql:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_USER=micromdm
+      - POSTGRES_PASSWORD=micromdm
+      - POSTGRES_DB=micromdm
+      - SSLMODE=disable
+  mdm:
+    build: .
+    image: micromdm
+#    image: micromdm/micromdm:latest
+    links:
+      - postgres:db
+      - redis
+    depends_on:
+      - postgres 
+      - redis
+    ports:
+      - "6443:6443"
+    volumes:
+      - ./mdm:/mdm
+    environment:
+      MICROMDM_HTTP_LISTEN_PORT: 8443
+      MICROMDM_USE_TLS: 'true' 
+      MICROMDM_TLS_CERT: /mdm/mdm.cer
+      MICROMDM_TLS_KEY: /mdm/mdm.key
+      MICROMDM_PUSH_CERT: /mdm/push.p12
+      MICROMDM_PUSH_PASS: sekret
+      MICROMDM_ENROLL_PROFILE: /mdm/enroll.mobileConfig
+      MICROMDM_PKG_REPO: /mdm/pkgrepo
+#      MICROMDM_POSTGRES_CONN_URL: 'postgresql://micromdm:micromdm@db/micromdm?sslmode=disable'
+      DEP_CONSUMER_KEY: na
+      DEP_CONSUMER_SECRET: na
+      DEP_ACCESS_TOKEN: na
+      DEP_ACCESS_SECRET: na
+      DEP_USE_DEPSIM: 'false' 
+      DEP_SERVER_URL: NA 
+
+volumes:
+  redis:
+  postgresql:
+  mdm:

--- a/docker-compose-v2.yml
+++ b/docker-compose-v2.yml
@@ -26,7 +26,7 @@ services:
       - postgres 
       - redis
     ports:
-      - "6443:6443"
+      - "6443:8443"
     volumes:
       - ./mdm:/mdm
     environment:
@@ -38,7 +38,10 @@ services:
       MICROMDM_PUSH_PASS: sekret
       MICROMDM_ENROLL_PROFILE: /mdm/enroll.mobileConfig
       MICROMDM_PKG_REPO: /mdm/pkgrepo
-#      MICROMDM_POSTGRES_CONN_URL: 'postgresql://micromdm:micromdm@db/micromdm?sslmode=disable'
+      # Connection string parameters are described here: https://godoc.org/github.com/lib/pq
+      MICROMDM_POSTGRES_CONN_URL: 'postgres://micromdm:micromdm@db/micromdm?sslmode=disable'
+      # Redis connection expects host:port
+      MICROMDM_REDIS_CONN_URL: 'redis:6379'
       DEP_CONSUMER_KEY: na
       DEP_CONSUMER_SECRET: na
       DEP_ACCESS_TOKEN: na


### PR DESCRIPTION
Add example docker-compose file using v2 format.
It isn't exactly perfect especially the volume configuration, but it's a fair reference to all of the ENV var parameters.
