### PR TITLE
Commands management

### DIFF
--- a/command/datastore.go
+++ b/command/datastore.go
@@ -130,15 +130,15 @@ func (rds redisDB) Commands(deviceUDID string) ([]mdm.Payload, error) {
 	conn := rds.pool.Get()
 	defer conn.Close()
 
-	commandUuids, err := redis.Values(conn.Do("LRANGE", deviceUDID, "0", "-1"))
+	commandUUIDs, err := redis.Values(conn.Do("LRANGE", deviceUDID, "0", "-1"))
 	if err != nil {
 		return nil, err
 	}
 
-	var payloads []mdm.Payload = make([]mdm.Payload, len(commandUuids))
+	var payloads []mdm.Payload = make([]mdm.Payload, len(commandUUIDs))
 
-	for i, commandUuid := range commandUuids {
-		payloadData, err := redis.Bytes(conn.Do("GET", commandUuid))
+	for i, commandUUID := range commandUUIDs {
+		payloadData, err := redis.Bytes(conn.Do("GET", commandUUID))
 		if err != nil {
 			return nil, err
 		}

--- a/command/datastore_test.go
+++ b/command/datastore_test.go
@@ -8,33 +8,34 @@ import (
 	"testing"
 )
 
-var (
+type datastoreFixtures struct {
 	ds     Datastore
 	logger log.Logger
-	err    error
-)
+}
 
-//func setup() {
-//	l = log.NewLogfmtLogger(os.Stdout)
-//	d, err := NewDB("redis", "localhost", l)
-//	if err != nil {
-//		panic("Test set up failed")
-//	}
-//}
-//
-//func teardown() {
-//
-//}
+func setup() (datastoreFixtures, error) {
+	logger := log.NewLogfmtLogger(os.Stdout)
+	commandsDb, err := NewDB("redis", "localhost", logger)
+	if err != nil {
+		return nil, err
+	}
+
+	return datastoreFixtures{ds: commandsDb, logger: logger}
+}
+
+func teardown() {
+
+}
 
 func TestService_Commands(t *testing.T) {
-	logger = log.NewLogfmtLogger(os.Stdout)
-	ds, err = NewDB("redis", "localhost:6379", logger)
+	fixtures, err := setup()
+	defer teardown()
 	if err != nil {
 		t.Errorf("error making new datastore: %v", err)
 	}
 
 	var commands []mdm.Payload
-	commands, err = ds.Commands("ABCDEF")
+	commands, err = fixtures.ds.Commands("ABCDEF")
 	if err != nil {
 		t.Errorf("datastore.Commands returned error: %v", err)
 	}

--- a/command/datastore_test.go
+++ b/command/datastore_test.go
@@ -1,0 +1,43 @@
+package command
+
+import (
+	"fmt"
+	"github.com/go-kit/kit/log"
+	"github.com/micromdm/mdm"
+	"os"
+	"testing"
+)
+
+var (
+	ds     Datastore
+	logger log.Logger
+	err    error
+)
+
+//func setup() {
+//	l = log.NewLogfmtLogger(os.Stdout)
+//	d, err := NewDB("redis", "localhost", l)
+//	if err != nil {
+//		panic("Test set up failed")
+//	}
+//}
+//
+//func teardown() {
+//
+//}
+
+func TestService_Commands(t *testing.T) {
+	logger = log.NewLogfmtLogger(os.Stdout)
+	ds, err = NewDB("redis", "localhost:6379", logger)
+	if err != nil {
+		t.Errorf("error making new datastore: %v", err)
+	}
+
+	var commands []mdm.Payload
+	commands, err = ds.Commands("ABCDEF")
+	if err != nil {
+		t.Errorf("datastore.Commands returned error: %v", err)
+	}
+
+	fmt.Printf("%v", commands)
+}

--- a/command/endpoint.go
+++ b/command/endpoint.go
@@ -98,3 +98,26 @@ func makeDeleteCommandEndpoint(svc Service) endpoint.Endpoint {
 		return deleteCommandResponse{Total: total}, nil
 	}
 }
+
+type getCommandsRequest struct {
+	UDID string
+}
+
+type getCommandsResponse struct {
+	Commands []mdm.Payload `json:"commands,omitempty"`
+	Err      error         `json:"error,omitempty"`
+}
+
+func makeGetCommandsEndpoint(svc Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(getCommandsRequest)
+		if req.UDID == "" {
+			return getCommandsResponse{Err: ErrEmptyRequest}, nil
+		}
+		commands, err := svc.Commands(req.UDID)
+		if err != nil {
+			return getCommandsResponse{Err: err}, nil
+		}
+		return getCommandsResponse{Commands: commands}, nil
+	}
+}

--- a/command/service.go
+++ b/command/service.go
@@ -7,6 +7,7 @@ type Service interface {
 	NewCommand(*mdm.CommandRequest) (*mdm.Payload, error)
 	NextCommand(udid string) ([]byte, int, error)
 	DeleteCommand(deviceUDID, commandUUID string) (int, error)
+	Commands(deviceUDID string) ([]mdm.Payload, error)
 }
 
 // NewService returns a new command service
@@ -48,4 +49,8 @@ func (svc service) NextCommand(udid string) ([]byte, int, error) {
 // DeleteCommand returns an MDM Payload from a list of queued payloads
 func (svc service) DeleteCommand(deviceUDID, commandUUID string) (int, error) {
 	return svc.db.DeleteCommand(deviceUDID, commandUUID)
+}
+
+func (svc service) Commands(deviceUDID string) ([]mdm.Payload, error) {
+	return svc.db.Commands(deviceUDID)
 }

--- a/command/service.go
+++ b/command/service.go
@@ -8,6 +8,7 @@ type Service interface {
 	NextCommand(udid string) ([]byte, int, error)
 	DeleteCommand(deviceUDID, commandUUID string) (int, error)
 	Commands(deviceUDID string) ([]mdm.Payload, error)
+	Find(commandUUID string) (*mdm.Payload, error)
 }
 
 // NewService returns a new command service
@@ -53,4 +54,8 @@ func (svc service) DeleteCommand(deviceUDID, commandUUID string) (int, error) {
 
 func (svc service) Commands(deviceUDID string) ([]mdm.Payload, error) {
 	return svc.db.Commands(deviceUDID)
+}
+
+func (svc service) Find(commandUUID string) (*mdm.Payload, error) {
+	return svc.db.Find(commandUUID)
 }

--- a/command/transport.go
+++ b/command/transport.go
@@ -38,9 +38,17 @@ func ServiceHandler(ctx context.Context, svc Service, logger kitlog.Logger) http
 		encodeResponse,
 		opts...,
 	)
+	getCommandsHandler := kithttp.NewServer(
+		ctx,
+		makeGetCommandsEndpoint(svc),
+		decodeGetCommandsRequest,
+		encodeResponse,
+		opts...,
+	)
 
 	r := mux.NewRouter()
 
+	r.Handle("/mdm/commands/{udid}", getCommandsHandler).Methods("GET")
 	r.Handle("/mdm/commands", newCommandHandler).Methods("POST")
 	r.Handle("/mdm/commands/{udid}/next", nextCommandHandler).Methods("GET")
 	r.Handle("/mdm/commands/{udid}/{uuid}", deleteCommandHandler).Methods("DELETE")
@@ -78,6 +86,18 @@ func decodeDeleteCommandRequest(_ context.Context, r *http.Request) (interface{}
 	var request deleteCommandRequest
 	request.UDID = udid
 	request.UUID = uuid
+	return request, nil
+}
+
+func decodeGetCommandsRequest(_ context.Context, r *http.Request) (interface{}, error) {
+	vars := mux.Vars(r)
+	udid, ok := vars["udid"]
+	if !ok {
+		return nil, errBadRouting
+	}
+
+	var request getCommandsRequest
+	request.UDID = udid
 	return request, nil
 }
 

--- a/command/transport.go
+++ b/command/transport.go
@@ -96,8 +96,7 @@ func decodeGetCommandsRequest(_ context.Context, r *http.Request) (interface{}, 
 		return nil, errBadRouting
 	}
 
-	var request getCommandsRequest
-	request.UDID = udid
+	request := getCommandsRequest{UDID: udid}
 	return request, nil
 }
 


### PR DESCRIPTION
These commits represent the addition of datastore method + endpoint for listing pending commands.

It also replaces the response handling switch block by matching the command UUID of the response with an outstanding command UUID instead of switching on RequestType. This is more reliable because iOS devices do not reply with the RequestType of the request that generated the response.

Also kludge