### PR TITLE
add golang build container

### DIFF
--- a/.docker/builder/Dockerfile
+++ b/.docker/builder/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.7.1-alpine
+
+RUN apk add --update \
+        git \
+		bash \
+		musl-dev \
+		openssl
+
+
+COPY ./builder.sh /builder.sh
+
+VOLUME   /go/src/github.com/micromdm/micromdm
+WORKDIR  /go/src/github.com/micromdm/micromdm
+
+ENTRYPOINT ["/builder.sh"]
+

--- a/.docker/builder/builder.sh
+++ b/.docker/builder/builder.sh
@@ -40,7 +40,7 @@ NAME=micromdm
 
 build_release() {
   echo -n "=> $1-$2: "
-  GOOS=$1 GOARCH=$2 CGO_ENABLED=0 go build -i -o build/$NAME-$1-$2 -ldflags "-X main.Version=$VERSION -X main.gitHash=`git rev-parse HEAD`" ./main.go
+  GOGC=500 GOOS=$1 GOARCH=$2 CGO_ENABLED=0 go build -i -o build/$NAME-$1-$2 -ldflags "-X main.Version=$VERSION -X main.gitHash=`git rev-parse HEAD`" ./main.go
   du -h build/$NAME-$1-$2
 }
 

--- a/.docker/builder/builder.sh
+++ b/.docker/builder/builder.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+usage() {
+  base="$(basename "$0")"
+  cat <<EOUSAGE
+Usage: ${base} [args]
+  -T,--test             : Run tests
+  -B,--build            : Build a release
+EOUSAGE
+}
+
+if [ $# -eq 0 ]; then
+  usage
+fi
+
+# Flag parsing
+while [[ $# -gt 0 ]]; do
+  opt="$1"
+  case "${opt}" in
+    -B|--build)
+      build=1
+      shift
+      ;;
+    -T|--tests)
+      tests=1
+      shift
+      ;;
+    *)
+      echo "Error: Unknown option: ${opt}"
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+VERSION="0.1.0.1-dev"
+NAME=micromdm
+
+build_release() {
+  echo -n "=> $1-$2: "
+  GOOS=$1 GOARCH=$2 CGO_ENABLED=0 go build -i -o build/$NAME-$1-$2 -ldflags "-X main.Version=$VERSION -X main.gitHash=`git rev-parse HEAD`" ./main.go
+  du -h build/$NAME-$1-$2
+}
+
+build=${build:-0}
+if [ ${build} -eq 1 ]; then
+    mkdir -p build
+    build_release "darwin" "amd64"
+    build_release "linux" "amd64"
+  exit 0
+fi
+
+tests=${tests:-0}
+if [ ${tests} -eq 1 ]; then
+    echo "not implemented"
+  exit 0
+fi


### PR DESCRIPTION
Adding a `micromdm/builder` container which runs tests and creates a server binary.
Would be useful to add to CI and for building releases. 
