### PR TITLE
Hotfix/last check in

### DIFF
--- a/checkin/service.go
+++ b/checkin/service.go
@@ -8,6 +8,7 @@ import (
 	"github.com/micromdm/micromdm/command"
 	"github.com/micromdm/micromdm/device"
 	"github.com/micromdm/micromdm/management"
+	"time"
 )
 
 // Service defines methods for and MDM Checkin service
@@ -60,6 +61,7 @@ func (svc service) Authenticate(cmd mdm.CheckinCommand) error {
 		MDMTopic:     cmd.Topic,
 		Model:        cmd.Model,
 		DeviceName:   cmd.DeviceName,
+		LastCheckin:  time.Now().UTC(),
 	}
 
 	_, err := svc.devices.New("authenticate", dev)
@@ -83,6 +85,8 @@ func (svc service) TokenUpdate(cmd mdm.CheckinCommand) error {
 	existing.UnlockToken = unlockToken
 	existing.AwaitingConfiguration = cmd.AwaitingConfiguration
 	existing.Enrolled = true
+	existing.LastCheckin = time.Now().UTC()
+
 	err = svc.devices.Save("tokenUpdate", existing)
 	if err != nil {
 		return err

--- a/connect/service.go
+++ b/connect/service.go
@@ -123,8 +123,7 @@ func (svc service) ackQueryResponses(req mdm.Response) error {
 
 	existing := devices[0]
 
-	now := time.Now()
-	existing.LastCheckin = &now
+	existing.LastCheckin = time.Now().UTC()
 	existing.LastQueryResponse, err = json.Marshal(req.QueryResponses)
 
 	if err != nil {

--- a/device/device.go
+++ b/device/device.go
@@ -48,11 +48,11 @@ type Device struct {
 	AssetTag               string           `json:"asset_tag,omitempty" db:"asset_tag"`
 	DEPProfileStatus       DEPProfileStatus `json:"dep_profile_status,omitempty" db:"dep_profile_status"`
 	DEPProfileUUID         string           `json:"dep_profile_uuid,omitempty" db:"dep_profile_uuid"`
-	DEPProfileAssignTime   *time.Time       `json:"dep_profile_assign_time,omitempty" db:"dep_profile_assign_time"`
-	DEPProfilePushTime     *time.Time       `json:"dep_profile_push_time,omitempty" db:"dep_profile_push_time"`
-	DEPProfileAssignedDate *time.Time       `json:"dep_profile_assigned_date,omitempty" db:"dep_profile_assigned_date"`
+	DEPProfileAssignTime   time.Time        `json:"dep_profile_assign_time,omitempty" db:"dep_profile_assign_time"`
+	DEPProfilePushTime     time.Time        `json:"dep_profile_push_time,omitempty" db:"dep_profile_push_time"`
+	DEPProfileAssignedDate time.Time        `json:"dep_profile_assigned_date,omitempty" db:"dep_profile_assigned_date"`
 	DEPProfileAssignedBy   string           `json:"dep_profile_assigned_by,omitempty" db:"dep_profile_assigned_by"`
-	LastCheckin            *time.Time       `json:"last_checkin" db:"last_checkin"`
+	LastCheckin            time.Time        `json:"last_checkin" db:"last_checkin"`
 	DeviceName             string           `json:"device_name" db:"device_name"`
 	LastQueryResponse      []byte           `json:"last_query_response" db:"last_query_response"`
 }

--- a/migrations/201610120001_devices_default_timestamp_down.sql
+++ b/migrations/201610120001_devices_default_timestamp_down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE devices
+  ALTER COLUMN dep_profile_assign_time DROP DEFAULT,
+  ALTER COLUMN dep_profile_push_time DROP DEFAULT,
+  ALTER COLUMN dep_profile_assigned_date DROP DEFAULT,
+  ALTER COLUMN last_checkin DROP DEFAULT;

--- a/migrations/201610120001_devices_default_timestamp_up.sql
+++ b/migrations/201610120001_devices_default_timestamp_up.sql
@@ -1,0 +1,9 @@
+-- Add golang's zero value for time.Time as the default column value for last_checkin which allows us to pass time.Time
+-- as a value type as per the docs.
+ALTER TABLE devices
+  ALTER COLUMN dep_profile_assign_time SET DEFAULT '0001-01-01 00:00:00',
+  ALTER COLUMN dep_profile_push_time SET DEFAULT '0001-01-01 00:00:00',
+  ALTER COLUMN dep_profile_assigned_date SET DEFAULT '0001-01-01 00:00:00',
+  ALTER COLUMN last_checkin SET DEFAULT '0001-01-01 00:00:00'
+
+


### PR DESCRIPTION
I noticed this paragraph from godoc [time.Time](https://golang.org/pkg/time/#Time)

> Programs using times should typically store and pass them as values, not pointers. That is, time variables and struct fields should be of type time.Time, not *time.Time. A Time value can be used by multiple goroutines simultaneously.

So:
- I altered the Device struct so that all time values used time.Time value types.
- To prevent database queries resulting in null values the default column value for device timestamps is the golang zero value `0001-01-01`.

Additionally:
- All places where the client contacts the mdm service updates the `last_checkin` field in the database to reflect the last contact time.
- The `last_checkin` field now holds the **UTC** datetime value, and the client is responsible for displaying in the local timezone.

