### PR TITLE
Add new travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: go
+go:
+  - 1.7
+  - tip
+
+services:
+  - redis-server
+  - postgresql
+
+before_script:
+  - psql -c 'create database travis_ci_test;' -U postgres
+
+before_install:
+  - sudo add-apt-repository ppa:masterminds/glide -y
+  - sudo apt-get update -q
+  - sudo apt-get install glide -y


### PR DESCRIPTION
At some point in time the Travis CI configuration was removed from the project (looks like a branch deleted around August 2016).

I've made a start on one even though our test coverage isn't great. At least it can catch build errors and sql migration statement problems.

The configuration includes *postgresql* and *redis* services for integration testing later on.

Give it a look over.