### PR TITLE
Fix some situations where enrolment could fail

### DIFF
--- a/enroll/profile.go
+++ b/enroll/profile.go
@@ -31,7 +31,7 @@ type Profile struct {
 	PayloadScope             string            `json:"scope" db:"scope" plist:",omitempty"`
 	RemovalDate              *time.Time        `json:"removal_date" db:"removal_date" plist:"-" plist:",omitempty"`
 	DurationUntilRemoval     float32           `json:"duration_until_removal" db:"duration_until_removal" plist:",omitempty"`
-	ConsentText              map[string]string `json:"consent_text" db:"consent_text" plist:"omitempty"`
+	ConsentText              map[string]string `json:"consent_text" db:"consent_text" plist:",omitempty"`
 }
 
 func NewProfile() *Profile {

--- a/main.go
+++ b/main.go
@@ -239,7 +239,7 @@ func main() {
 		if *flTLSCACert == "" {
 			logger.Log("warn", "You did not specify a CA Certificate to trust via --tls-ca-cert or MICROMDM_TLS_CA_CERT. If your certificates are self signed, devices may not be able to enroll.")
 		}
-		enrollSvc, _ := enroll.NewService(*flPushCert, *flPushPass, *flTLSCACert, *flSCEPURL, *flSCEPChallenge, *flURL)
+		enrollSvc, _ := enroll.NewService(*flPushCert, *flPushPass, *flTLSCACert, *flSCEPURL, *flSCEPChallenge, *flURL, *flTLSCert)
 		enrollHandler := enroll.MakeHTTPHandler(ctx, enrollSvc, httpLogger)
 		mux.Handle("/mdm/enroll", enrollHandler)
 	}


### PR DESCRIPTION
- FIX: ConsentText had the wrong struct tag leading to a key called `omitempty` in the enroll plist.
- Enrollment service now takes a TLS certificate in the case that you are using a self-signed certificate, and that certificate is now added as a payload at enrollment time to resolve a possible trust issue when enrolling to a self signed MDM.

