### PR TITLE
FIX: CA roots are not correctly being verified in main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -360,7 +360,6 @@ func serve(logger log.Logger, tlsEnabled bool, port, key, certPath string) {
 					logger.Log("err", "certificate is invalid")
 				}
 			}
-			os.Exit(1)
 		}
 
 		logger.Log("msg", "HTTPs", "addr", port)


### PR DESCRIPTION
Left warning in, but removed os.Exit until I can determine a reliable method of using the system trust store in a cross-platform way