### PR TITLE
Feature/dep optional

### DIFF
--- a/management/service.go
+++ b/management/service.go
@@ -121,6 +121,10 @@ func (svc service) DeleteProfile(uuid string) error {
 }
 
 func (svc service) FetchDEPDevices() error {
+	if svc.depClient == nil {
+		return errors.New("feature not available")
+	}
+
 	fetched, err := svc.depClient.FetchDevices(dep.Limit(100))
 	if err != nil {
 		return errors.Wrap(err, "management: dep fetch")


### PR DESCRIPTION
depClient() function to construct a client may now return an error as second argument, indicating that the DEP client is not available.
management.Service will return an error "feature not available" if you attempt to use dep fetch and don't supply a DEP client.
management test teardown via gomigrate rollback
new management test ensures that constructing the management service without a dep client actually works and the endpoint does not cause a panic.