### PR TITLE
refactor package main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ GO    		:= GO15VENDOREXPERIMENT=1 go
 glide    	:= glide
 release    	:= ./release.sh
 
+.PHONY: all build deps docker
+
 all: build
 
 deps: 

--- a/app/app.go
+++ b/app/app.go
@@ -1,0 +1,355 @@
+package app
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/go-kit/kit/log"
+)
+
+// exit status
+const (
+	success int = iota
+	badReturn
+	badInput
+)
+
+func Main() int {
+	logger := log.NewLogfmtLogger(os.Stderr)
+	logger = log.NewContext(logger).WithPrefix("domain", "config")
+	_, err := loadConfig()
+	if err != nil {
+		logger.Log("err", err)
+		return badInput
+	}
+	return success
+}
+
+func loadConfig() (*Config, error) {
+
+	// cli flags, using environment variables as a possible default.
+	var (
+		// tls config
+		flTLS     = flag.Bool("tls", envBool("MICROMDM_USE_TLS"), "use https")
+		flTLSCert = flag.String("tls-cert", envString("MICROMDM_TLS_CERT", ""), "path to TLS certificate")
+		flTLSKey  = flag.String("tls-key", envString("MICROMDM_TLS_KEY", ""), "path to TLS private key")
+
+		// dep config
+		flDEP          = flag.Bool("dep", envBool("MICROMDM_USE_DEP"), "use DEP")
+		flDEPCK        = flag.String("dep-consumer-key", envString("DEP_CONSUMER_KEY", ""), "dep consumer key")
+		flDEPCS        = flag.String("dep-consumer-secret", envString("DEP_CONSUMER_SECRET", ""), "dep consumer secret")
+		flDEPAT        = flag.String("dep-access-token", envString("DEP_ACCESS_TOKEN", ""), "dep access token")
+		flDEPAS        = flag.String("dep-access-secret", envString("DEP_ACCESS_SECRET", ""), "dep access secret")
+		flDEPSim       = flag.Bool("depsim", envBool("DEP_USE_DEPSIM"), "use default depsim credentials")
+		flDEPServerURL = flag.String("dep-server-url", envString("DEP_SERVER_URL", ""), "dep server url. for testing. Use blank if not running against depsim")
+
+		// server settings
+		flURL         = flag.String("url", envString("MICROMDM_URL", ""), "public url of the server")
+		flAddress     = flag.String("http-address", envString("MICROMDM_HTTP_LISTEN_ADDRESS", "0.0.0.0"), "address to listen on.")
+		flCORSOrigins = flag.String("cors-origin", envString("MICROMDM_CORS_ORIGINS", ""), "allowed domain for cross origin resource sharing. comma separated")
+		flPkgRepo     = flag.String("pkg-repo", envString("MICROMDM_PKG_REPO", ""), "path to a folder with packages for use with InstallApplication")
+
+		// scep config. use the cert chain from enrollment if provided.
+		flSCEPURL       = flag.String("scep-url", envString("MICROMDM_SCEP_URL", ""), "scep server url. If blank, enroll profile will not use a scep payload")
+		flSCEPChallenge = flag.String("scep-challenge", envString("MICROMDM_SCEP_CHALLENGE", ""), "scep server challenge")
+		flSCEPSubject   = flag.String("scep-subject", envString("MICROMDM_SCEP_SUBJECT", ""), "scep request subject in microsoft string representation")
+
+		// enrollment config.
+		flEnrollment    = flag.String("enrollment-profile", envString("MICROMDM_ENROLL_PROFILE", ""), "path to enrollment profile")
+		flServerCAChain = flag.String("tls-ca-cert", envString("MICROMDM_TLS_CA_CHAIN", ""), "path to CA certificate chain for trust profile")
+
+		// postgres connection flag. will also try to load from docker link.
+		flPGconn = flag.String("postgres", envString("MICROMDM_POSTGRES_CONN_URL", ""), "postgres connection url")
+		// redis connection flag. will also try to load from docker link.
+		flRedisConn = flag.String("redis", envString("MICROMDM_REDIS_CONN_URL", ""), "redis connection url")
+
+		// flVersion       = flag.Bool("version", false, "print version information")
+
+		// APNS config. Can be either two files or a combined .p12 (like the one exported from keychain access")
+		flPushCert = flag.String("push-cert", envString("MICROMDM_PUSH_CERT", ""), "path to push certificate")
+		flPushPass = flag.String("push-password", envString("MICROMDM_PUSH_PASSWORD", ""), "push certificate password")
+		flPushKey  = flag.String("push-key", envString("MICROMDM_PUSH_KEY", ""), "path to push certificate private key(if not using a single .p12 file)")
+	)
+	flag.Parse()
+
+	config := &Config{}
+	config.loadTLS(*flTLS, *flTLSCert, *flTLSKey)
+	config.loadDEPConfig(*flDEP, *flDEPSim, *flDEPCS, *flDEPCK, *flDEPAT, *flDEPAS, *flDEPServerURL)
+	config.loadServerConfig(*flURL, *flAddress, *flCORSOrigins, *flPkgRepo)
+	config.loadSCEPConfig(*flSCEPURL, *flSCEPChallenge, *flSCEPSubject)
+	config.loadEnrollmentConfig(*flEnrollment, *flServerCAChain)
+	config.loadPostgres(*flPGconn)
+	config.loadRedis(*flRedisConn)
+	config.loadPushConfig(*flPushCert, *flPushKey, *flPushPass)
+	if config.err != nil {
+		return nil, config.err
+	}
+	return config, nil
+}
+
+// Config holds configuration values for MicroMDM. The config values
+// can be loaded from CLI flags or environment variables.
+type Config struct {
+	TLS        *TLSConfig
+	DEP        *DEPConfig
+	SCEP       *SCEPConfig
+	APNS       *PushConfig
+	Enrollment *EnrollmentConfig
+	Redis      *RedisConfig
+	Postgres   *PostgresConfig
+	Server     *ServerConfig
+
+	// the err value is part of the config struct to allow multiple
+	// 'loadConfigFoo' calls in sequence, without checking if err != nil every time.
+	err error
+}
+
+type TLSConfig struct {
+	Enabled         bool
+	CertificatePath string
+	PrivateKeyPath  string
+}
+
+func (c *Config) loadTLS(enabled bool, cert, key string) {
+	if c.err != nil {
+		return
+	}
+	config := &TLSConfig{
+		Enabled:         enabled,
+		CertificatePath: cert,
+		PrivateKeyPath:  key,
+	}
+	if enabled && (cert == "" || key == "") {
+		c.err = errors.New("certificate or key path missing in TLS config")
+		return
+	}
+	c.TLS = config
+}
+
+// DEPConfig holds configuration values for the DEP API.
+// If UseSim is true, the default depsim values will be used instead.
+// When usind depsim, a ServerURL value must be specified.
+type DEPConfig struct {
+	Enabled        bool
+	UseSim         bool
+	ServerURL      string
+	ConsumerKey    string
+	ConsumerSecret string
+	AccessToken    string
+	AccessSecret   string
+}
+
+func (c *Config) loadDEPConfig(enabled, sim bool, ck, cs, at, as, serverURL string) {
+	if c.err != nil {
+		return
+	}
+	config := &DEPConfig{
+		Enabled:        enabled,
+		UseSim:         sim,
+		ConsumerKey:    ck,
+		ConsumerSecret: cs,
+		AccessToken:    at,
+		AccessSecret:   as,
+		ServerURL:      serverURL,
+	}
+	if sim {
+		config.ConsumerKey = "CK_48dd68d198350f51258e885ce9a5c37ab7f98543c4a697323d75682a6c10a32501cb247e3db08105db868f73f2c972bdb6ae77112aea803b9219eb52689d42e6"
+		config.ConsumerSecret = "CS_34c7b2b531a600d99a0e4edcf4a78ded79b86ef318118c2f5bcfee1b011108c32d5302df801adbe29d446eb78f02b13144e323eb9aad51c79f01e50cb45c3a68"
+		config.AccessToken = "AT_927696831c59ba510cfe4ec1a69e5267c19881257d4bca2906a99d0785b785a6f6fdeb09774954fdd5e2d0ad952e3af52c6d8d2f21c924ba0caf4a031c158b89"
+		config.AccessSecret = "AS_c31afd7a09691d83548489336e8ff1cb11b82b6bca13f793344496a556b1f4972eaff4dde6deb5ac9cf076fdfa97ec97699c34d515947b9cf9ed31c99dded6ba"
+	}
+	if sim && serverURL == "" {
+		c.err = errors.New("dep-server-url must be specified when using depsim")
+		return
+	}
+	c.DEP = config
+}
+
+// ServerConfig holds server configuration values.
+// The ListenURL is used for the server listen Addr and the PublicURL
+// is used for embedding the URL in profiles/notification emails etc.
+// The public url is the URL used to connect to micromdm.
+// TODO: PublicURL should be configured via the API/stored in DB.
+type ServerConfig struct {
+	PublicURL       string
+	ListenURL       string
+	CORSOrigins     []string
+	PackageRepoPath string
+}
+
+func (c *Config) loadServerConfig(publicURL, listenURL, cors, repoPath string) {
+	if c.err != nil {
+		return
+	}
+	config := &ServerConfig{
+		PublicURL:       publicURL,
+		ListenURL:       listenURL,
+		CORSOrigins:     strings.Split(cors, ","),
+		PackageRepoPath: repoPath,
+	}
+	if listenURL == "" {
+		config.ListenURL = "0.0.0.0:8080"
+	}
+	if publicURL == "" {
+		config.PublicURL = "127.0.0.1:8080"
+	}
+	c.Server = config
+}
+
+// SCEPConfig holds configuration for the SCEP service.
+// The SCEP service can be either local or remote. If the SCEP service
+// is disabled, a enrollment profile with an identity certificate must be
+// used instead.
+type SCEPConfig struct {
+	Enabled            bool
+	Embedded           bool
+	RemoteURL          string
+	Challenge          string
+	CertificateSubject string
+}
+
+func (c *Config) loadSCEPConfig(remoteURL, challenge, certSubject string) {
+	if c.err != nil {
+		return
+	}
+	config := &SCEPConfig{
+		Enabled:            remoteURL != "",
+		Embedded:           false, // TODO
+		RemoteURL:          remoteURL,
+		Challenge:          challenge,
+		CertificateSubject: certSubject,
+	}
+	c.SCEP = config
+	// FIXME add validation
+}
+
+// EnrollmentConfig holds configuration for enrollment without SCEP.
+// The ProfilePath must point to a .mobileconfig file.
+// An optional path to the server root certificate can also be provided. Use
+// this for adding a trust profile.
+type EnrollmentConfig struct {
+	ProfilePath string // TODO use a template?
+	CACertPath  string
+}
+
+func (c *Config) loadEnrollmentConfig(profile, certChain string) {
+	if c.err != nil {
+		return
+	}
+	config := &EnrollmentConfig{
+		ProfilePath: profile,
+		CACertPath:  certChain,
+	}
+	c.Enrollment = config
+}
+
+type PostgresConfig struct {
+	Enabled    bool
+	Connection string
+}
+
+func (c *Config) loadPostgres(conn string) {
+	if c.err != nil {
+		return
+	}
+	config := &PostgresConfig{
+		Enabled:    true, // currently required.
+		Connection: conn,
+	}
+	if conn == "" {
+		config.fromDockerEnv()
+	}
+	if conn == "" {
+		c.err = errors.New("must provide postgres connection string")
+		return
+	}
+	c.Postgres = config
+}
+
+// FromDockerEnv tries to load postgres connection info from a docker link.
+// The name of the link is assumed to be "postgres".
+// env values taken from https://hub.docker.com/_/postgres/
+func (c *PostgresConfig) fromDockerEnv() {
+	host, ok := os.LookupEnv("POSTGRES_PORT_5432_TCP_ADDR")
+	if !ok {
+		return // don't bother with the rest.
+	}
+	user := os.Getenv("POSTGRES_ENV_POSTGRES_USER")
+	if user == "" {
+		user = "postgres"
+	}
+	dbname := os.Getenv("POSTGRES_ENV_POSTGRES_DB")
+	if dbname == "" {
+		dbname = user //same defaults as the docker pgcontainer
+	}
+	password := os.Getenv("POSTGRES_ENV_POSTGRES_PASSWORD")
+	if password == "" {
+		password = "postgres"
+	}
+	sslmode := os.Getenv("POSTGRES_ENV_SSLMODE")
+	if sslmode == "" {
+		sslmode = "require"
+	}
+	c.Connection = fmt.Sprintf("user=%v password=%v dbname=%v sslmode=%v host=%v", user, password, dbname, sslmode, host)
+}
+
+type RedisConfig struct {
+	Enabled    bool
+	Connection string
+}
+
+func (c *Config) loadRedis(conn string) {
+	if c.err != nil {
+		return
+	}
+	config := &RedisConfig{
+		Enabled:    true, // currently required.
+		Connection: conn,
+	}
+	if conn == "" {
+		config.fromDockerEnv()
+	}
+	if conn == "" {
+		c.err = errors.New("must provide redis connection string")
+		return
+	}
+	c.Redis = config
+}
+
+// FromDockerEnv tries to load connection information from a linked Docker
+// container. The name of the link is assumed to be "redis".
+func (c *RedisConfig) fromDockerEnv() {
+	host, ok := os.LookupEnv("REDIS_PORT_6379_TCP_ADDR")
+	if !ok {
+		return
+	}
+	port := os.Getenv("REDIS_PORT_6379_TCP_PORT")
+	c.Connection = fmt.Sprintf("%v:%v", host, port)
+}
+
+// PushConfig holds values for connecting to APNS. The private key can be either
+// a PEM or a p12 file.
+type PushConfig struct {
+	CertificatePath string
+	PrivateKeyPath  string
+	PrivateKeyPass  string
+}
+
+func (c *Config) loadPushConfig(certPath, keyPath, keyPassword string) {
+	if c.err != nil {
+		return
+	}
+	config := &PushConfig{
+		CertificatePath: certPath,
+		PrivateKeyPath:  keyPath,
+		PrivateKeyPass:  keyPassword,
+	}
+	if certPath == "" {
+		c.err = errors.New("must provide MDM push certificate")
+		return
+	}
+	c.APNS = config
+}

--- a/app/app.go
+++ b/app/app.go
@@ -1,355 +1,39 @@
+// Package app sets up and manages the MicroMDM server application which
+// is composed of multiple independent components such as datastores and
+// services.
 package app
 
-import (
-	"errors"
-	"flag"
-	"fmt"
-	"os"
-	"strings"
-
-	"github.com/go-kit/kit/log"
-)
+import "github.com/go-kit/kit/log"
 
 // exit status
 const (
-	success int = iota
-	badReturn
-	badInput
+	success   int = iota
+	badReturn     // general errors
+	badInput      // issue with CLI input
 )
 
-func Main() int {
-	logger := log.NewLogfmtLogger(os.Stderr)
-	logger = log.NewContext(logger).WithPrefix("domain", "config")
-	_, err := loadConfig()
+// Main is MicroMDM's main() function. Main parses the CLI options given
+// by the user and sets up an HTTP service for all the services built into
+// MicroMDM.
+func Main(logger log.Logger) (status int, err error) {
+	config, err := loadConfig()
 	if err != nil {
-		logger.Log("err", err)
-		return badInput
+		return badInput, err
 	}
-	return success
-}
-
-func loadConfig() (*Config, error) {
-
-	// cli flags, using environment variables as a possible default.
-	var (
-		// tls config
-		flTLS     = flag.Bool("tls", envBool("MICROMDM_USE_TLS"), "use https")
-		flTLSCert = flag.String("tls-cert", envString("MICROMDM_TLS_CERT", ""), "path to TLS certificate")
-		flTLSKey  = flag.String("tls-key", envString("MICROMDM_TLS_KEY", ""), "path to TLS private key")
-
-		// dep config
-		flDEP          = flag.Bool("dep", envBool("MICROMDM_USE_DEP"), "use DEP")
-		flDEPCK        = flag.String("dep-consumer-key", envString("DEP_CONSUMER_KEY", ""), "dep consumer key")
-		flDEPCS        = flag.String("dep-consumer-secret", envString("DEP_CONSUMER_SECRET", ""), "dep consumer secret")
-		flDEPAT        = flag.String("dep-access-token", envString("DEP_ACCESS_TOKEN", ""), "dep access token")
-		flDEPAS        = flag.String("dep-access-secret", envString("DEP_ACCESS_SECRET", ""), "dep access secret")
-		flDEPSim       = flag.Bool("depsim", envBool("DEP_USE_DEPSIM"), "use default depsim credentials")
-		flDEPServerURL = flag.String("dep-server-url", envString("DEP_SERVER_URL", ""), "dep server url. for testing. Use blank if not running against depsim")
-
-		// server settings
-		flURL         = flag.String("url", envString("MICROMDM_URL", ""), "public url of the server")
-		flAddress     = flag.String("http-address", envString("MICROMDM_HTTP_LISTEN_ADDRESS", "0.0.0.0"), "address to listen on.")
-		flCORSOrigins = flag.String("cors-origin", envString("MICROMDM_CORS_ORIGINS", ""), "allowed domain for cross origin resource sharing. comma separated")
-		flPkgRepo     = flag.String("pkg-repo", envString("MICROMDM_PKG_REPO", ""), "path to a folder with packages for use with InstallApplication")
-
-		// scep config. use the cert chain from enrollment if provided.
-		flSCEPURL       = flag.String("scep-url", envString("MICROMDM_SCEP_URL", ""), "scep server url. If blank, enroll profile will not use a scep payload")
-		flSCEPChallenge = flag.String("scep-challenge", envString("MICROMDM_SCEP_CHALLENGE", ""), "scep server challenge")
-		flSCEPSubject   = flag.String("scep-subject", envString("MICROMDM_SCEP_SUBJECT", ""), "scep request subject in microsoft string representation")
-
-		// enrollment config.
-		flEnrollment    = flag.String("enrollment-profile", envString("MICROMDM_ENROLL_PROFILE", ""), "path to enrollment profile")
-		flServerCAChain = flag.String("tls-ca-cert", envString("MICROMDM_TLS_CA_CHAIN", ""), "path to CA certificate chain for trust profile")
-
-		// postgres connection flag. will also try to load from docker link.
-		flPGconn = flag.String("postgres", envString("MICROMDM_POSTGRES_CONN_URL", ""), "postgres connection url")
-		// redis connection flag. will also try to load from docker link.
-		flRedisConn = flag.String("redis", envString("MICROMDM_REDIS_CONN_URL", ""), "redis connection url")
-
-		// flVersion       = flag.Bool("version", false, "print version information")
-
-		// APNS config. Can be either two files or a combined .p12 (like the one exported from keychain access")
-		flPushCert = flag.String("push-cert", envString("MICROMDM_PUSH_CERT", ""), "path to push certificate")
-		flPushPass = flag.String("push-password", envString("MICROMDM_PUSH_PASSWORD", ""), "push certificate password")
-		flPushKey  = flag.String("push-key", envString("MICROMDM_PUSH_KEY", ""), "path to push certificate private key(if not using a single .p12 file)")
+	sm, err := setupServices(config, logger)
+	if err != nil {
+		return badReturn, err
+	}
+	err = serveHTTP(
+		logger,
+		makeHTTPHandler(logger, sm),
+		config.TLS.Enabled,
+		config.Server.ListenURL,
+		config.TLS.PrivateKeyPath,
+		config.TLS.CertificatePath,
 	)
-	flag.Parse()
-
-	config := &Config{}
-	config.loadTLS(*flTLS, *flTLSCert, *flTLSKey)
-	config.loadDEPConfig(*flDEP, *flDEPSim, *flDEPCS, *flDEPCK, *flDEPAT, *flDEPAS, *flDEPServerURL)
-	config.loadServerConfig(*flURL, *flAddress, *flCORSOrigins, *flPkgRepo)
-	config.loadSCEPConfig(*flSCEPURL, *flSCEPChallenge, *flSCEPSubject)
-	config.loadEnrollmentConfig(*flEnrollment, *flServerCAChain)
-	config.loadPostgres(*flPGconn)
-	config.loadRedis(*flRedisConn)
-	config.loadPushConfig(*flPushCert, *flPushKey, *flPushPass)
-	if config.err != nil {
-		return nil, config.err
+	if err != nil {
+		return badReturn, err
 	}
-	return config, nil
-}
-
-// Config holds configuration values for MicroMDM. The config values
-// can be loaded from CLI flags or environment variables.
-type Config struct {
-	TLS        *TLSConfig
-	DEP        *DEPConfig
-	SCEP       *SCEPConfig
-	APNS       *PushConfig
-	Enrollment *EnrollmentConfig
-	Redis      *RedisConfig
-	Postgres   *PostgresConfig
-	Server     *ServerConfig
-
-	// the err value is part of the config struct to allow multiple
-	// 'loadConfigFoo' calls in sequence, without checking if err != nil every time.
-	err error
-}
-
-type TLSConfig struct {
-	Enabled         bool
-	CertificatePath string
-	PrivateKeyPath  string
-}
-
-func (c *Config) loadTLS(enabled bool, cert, key string) {
-	if c.err != nil {
-		return
-	}
-	config := &TLSConfig{
-		Enabled:         enabled,
-		CertificatePath: cert,
-		PrivateKeyPath:  key,
-	}
-	if enabled && (cert == "" || key == "") {
-		c.err = errors.New("certificate or key path missing in TLS config")
-		return
-	}
-	c.TLS = config
-}
-
-// DEPConfig holds configuration values for the DEP API.
-// If UseSim is true, the default depsim values will be used instead.
-// When usind depsim, a ServerURL value must be specified.
-type DEPConfig struct {
-	Enabled        bool
-	UseSim         bool
-	ServerURL      string
-	ConsumerKey    string
-	ConsumerSecret string
-	AccessToken    string
-	AccessSecret   string
-}
-
-func (c *Config) loadDEPConfig(enabled, sim bool, ck, cs, at, as, serverURL string) {
-	if c.err != nil {
-		return
-	}
-	config := &DEPConfig{
-		Enabled:        enabled,
-		UseSim:         sim,
-		ConsumerKey:    ck,
-		ConsumerSecret: cs,
-		AccessToken:    at,
-		AccessSecret:   as,
-		ServerURL:      serverURL,
-	}
-	if sim {
-		config.ConsumerKey = "CK_48dd68d198350f51258e885ce9a5c37ab7f98543c4a697323d75682a6c10a32501cb247e3db08105db868f73f2c972bdb6ae77112aea803b9219eb52689d42e6"
-		config.ConsumerSecret = "CS_34c7b2b531a600d99a0e4edcf4a78ded79b86ef318118c2f5bcfee1b011108c32d5302df801adbe29d446eb78f02b13144e323eb9aad51c79f01e50cb45c3a68"
-		config.AccessToken = "AT_927696831c59ba510cfe4ec1a69e5267c19881257d4bca2906a99d0785b785a6f6fdeb09774954fdd5e2d0ad952e3af52c6d8d2f21c924ba0caf4a031c158b89"
-		config.AccessSecret = "AS_c31afd7a09691d83548489336e8ff1cb11b82b6bca13f793344496a556b1f4972eaff4dde6deb5ac9cf076fdfa97ec97699c34d515947b9cf9ed31c99dded6ba"
-	}
-	if sim && serverURL == "" {
-		c.err = errors.New("dep-server-url must be specified when using depsim")
-		return
-	}
-	c.DEP = config
-}
-
-// ServerConfig holds server configuration values.
-// The ListenURL is used for the server listen Addr and the PublicURL
-// is used for embedding the URL in profiles/notification emails etc.
-// The public url is the URL used to connect to micromdm.
-// TODO: PublicURL should be configured via the API/stored in DB.
-type ServerConfig struct {
-	PublicURL       string
-	ListenURL       string
-	CORSOrigins     []string
-	PackageRepoPath string
-}
-
-func (c *Config) loadServerConfig(publicURL, listenURL, cors, repoPath string) {
-	if c.err != nil {
-		return
-	}
-	config := &ServerConfig{
-		PublicURL:       publicURL,
-		ListenURL:       listenURL,
-		CORSOrigins:     strings.Split(cors, ","),
-		PackageRepoPath: repoPath,
-	}
-	if listenURL == "" {
-		config.ListenURL = "0.0.0.0:8080"
-	}
-	if publicURL == "" {
-		config.PublicURL = "127.0.0.1:8080"
-	}
-	c.Server = config
-}
-
-// SCEPConfig holds configuration for the SCEP service.
-// The SCEP service can be either local or remote. If the SCEP service
-// is disabled, a enrollment profile with an identity certificate must be
-// used instead.
-type SCEPConfig struct {
-	Enabled            bool
-	Embedded           bool
-	RemoteURL          string
-	Challenge          string
-	CertificateSubject string
-}
-
-func (c *Config) loadSCEPConfig(remoteURL, challenge, certSubject string) {
-	if c.err != nil {
-		return
-	}
-	config := &SCEPConfig{
-		Enabled:            remoteURL != "",
-		Embedded:           false, // TODO
-		RemoteURL:          remoteURL,
-		Challenge:          challenge,
-		CertificateSubject: certSubject,
-	}
-	c.SCEP = config
-	// FIXME add validation
-}
-
-// EnrollmentConfig holds configuration for enrollment without SCEP.
-// The ProfilePath must point to a .mobileconfig file.
-// An optional path to the server root certificate can also be provided. Use
-// this for adding a trust profile.
-type EnrollmentConfig struct {
-	ProfilePath string // TODO use a template?
-	CACertPath  string
-}
-
-func (c *Config) loadEnrollmentConfig(profile, certChain string) {
-	if c.err != nil {
-		return
-	}
-	config := &EnrollmentConfig{
-		ProfilePath: profile,
-		CACertPath:  certChain,
-	}
-	c.Enrollment = config
-}
-
-type PostgresConfig struct {
-	Enabled    bool
-	Connection string
-}
-
-func (c *Config) loadPostgres(conn string) {
-	if c.err != nil {
-		return
-	}
-	config := &PostgresConfig{
-		Enabled:    true, // currently required.
-		Connection: conn,
-	}
-	if conn == "" {
-		config.fromDockerEnv()
-	}
-	if conn == "" {
-		c.err = errors.New("must provide postgres connection string")
-		return
-	}
-	c.Postgres = config
-}
-
-// FromDockerEnv tries to load postgres connection info from a docker link.
-// The name of the link is assumed to be "postgres".
-// env values taken from https://hub.docker.com/_/postgres/
-func (c *PostgresConfig) fromDockerEnv() {
-	host, ok := os.LookupEnv("POSTGRES_PORT_5432_TCP_ADDR")
-	if !ok {
-		return // don't bother with the rest.
-	}
-	user := os.Getenv("POSTGRES_ENV_POSTGRES_USER")
-	if user == "" {
-		user = "postgres"
-	}
-	dbname := os.Getenv("POSTGRES_ENV_POSTGRES_DB")
-	if dbname == "" {
-		dbname = user //same defaults as the docker pgcontainer
-	}
-	password := os.Getenv("POSTGRES_ENV_POSTGRES_PASSWORD")
-	if password == "" {
-		password = "postgres"
-	}
-	sslmode := os.Getenv("POSTGRES_ENV_SSLMODE")
-	if sslmode == "" {
-		sslmode = "require"
-	}
-	c.Connection = fmt.Sprintf("user=%v password=%v dbname=%v sslmode=%v host=%v", user, password, dbname, sslmode, host)
-}
-
-type RedisConfig struct {
-	Enabled    bool
-	Connection string
-}
-
-func (c *Config) loadRedis(conn string) {
-	if c.err != nil {
-		return
-	}
-	config := &RedisConfig{
-		Enabled:    true, // currently required.
-		Connection: conn,
-	}
-	if conn == "" {
-		config.fromDockerEnv()
-	}
-	if conn == "" {
-		c.err = errors.New("must provide redis connection string")
-		return
-	}
-	c.Redis = config
-}
-
-// FromDockerEnv tries to load connection information from a linked Docker
-// container. The name of the link is assumed to be "redis".
-func (c *RedisConfig) fromDockerEnv() {
-	host, ok := os.LookupEnv("REDIS_PORT_6379_TCP_ADDR")
-	if !ok {
-		return
-	}
-	port := os.Getenv("REDIS_PORT_6379_TCP_PORT")
-	c.Connection = fmt.Sprintf("%v:%v", host, port)
-}
-
-// PushConfig holds values for connecting to APNS. The private key can be either
-// a PEM or a p12 file.
-type PushConfig struct {
-	CertificatePath string
-	PrivateKeyPath  string
-	PrivateKeyPass  string
-}
-
-func (c *Config) loadPushConfig(certPath, keyPath, keyPassword string) {
-	if c.err != nil {
-		return
-	}
-	config := &PushConfig{
-		CertificatePath: certPath,
-		PrivateKeyPath:  keyPath,
-		PrivateKeyPass:  keyPassword,
-	}
-	if certPath == "" {
-		c.err = errors.New("must provide MDM push certificate")
-		return
-	}
-	c.APNS = config
+	return success, nil
 }

--- a/app/config.go
+++ b/app/config.go
@@ -1,0 +1,342 @@
+package app
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/micromdm/micromdm/version"
+)
+
+func loadConfig() (*Config, error) {
+	// cli flags, using environment variables as a possible default.
+	var (
+		// tls config
+		flTLS     = flag.Bool("tls", envBool("MICROMDM_USE_TLS"), "use https")
+		flTLSCert = flag.String("tls-cert", envString("MICROMDM_TLS_CERT", ""), "path to TLS certificate")
+		flTLSKey  = flag.String("tls-key", envString("MICROMDM_TLS_KEY", ""), "path to TLS private key")
+
+		// dep config
+		flDEP          = flag.Bool("dep", envBool("MICROMDM_USE_DEP"), "use DEP")
+		flDEPCK        = flag.String("dep-consumer-key", envString("DEP_CONSUMER_KEY", ""), "dep consumer key")
+		flDEPCS        = flag.String("dep-consumer-secret", envString("DEP_CONSUMER_SECRET", ""), "dep consumer secret")
+		flDEPAT        = flag.String("dep-access-token", envString("DEP_ACCESS_TOKEN", ""), "dep access token")
+		flDEPAS        = flag.String("dep-access-secret", envString("DEP_ACCESS_SECRET", ""), "dep access secret")
+		flDEPSim       = flag.Bool("depsim", envBool("DEP_USE_DEPSIM"), "use default depsim credentials")
+		flDEPServerURL = flag.String("dep-server-url", envString("DEP_SERVER_URL", ""), "dep server url. for testing. Use blank if not running against depsim")
+
+		// server settings
+		flURL         = flag.String("url", envString("MICROMDM_URL", ""), "public url of the server")
+		flAddress     = flag.String("http-address", envString("MICROMDM_HTTP_LISTEN_ADDRESS", "0.0.0.0"), "address to listen on.")
+		flCORSOrigins = flag.String("cors-origin", envString("MICROMDM_CORS_ORIGINS", ""), "allowed domain for cross origin resource sharing. comma separated")
+		flPkgRepo     = flag.String("pkg-repo", envString("MICROMDM_PKG_REPO", ""), "path to a folder with packages for use with InstallApplication")
+
+		// scep config. use the cert chain from enrollment if provided.
+		flSCEPURL       = flag.String("scep-url", envString("MICROMDM_SCEP_URL", ""), "scep server url. If blank, enroll profile will not use a scep payload")
+		flSCEPChallenge = flag.String("scep-challenge", envString("MICROMDM_SCEP_CHALLENGE", ""), "scep server challenge")
+		flSCEPSubject   = flag.String("scep-subject", envString("MICROMDM_SCEP_SUBJECT", ""), "scep request subject in microsoft string representation")
+
+		// enrollment config.
+		flEnrollment    = flag.String("enrollment-profile", envString("MICROMDM_ENROLL_PROFILE", ""), "path to enrollment profile")
+		flServerCAChain = flag.String("tls-ca-cert", envString("MICROMDM_TLS_CA_CHAIN", ""), "path to CA certificate chain for trust profile")
+
+		// postgres connection flag. will also try to load from docker link.
+		flPGconn = flag.String("postgres", envString("MICROMDM_POSTGRES_CONN_URL", ""), "postgres connection url")
+
+		// redis connection flag. will also try to load from docker link.
+		flRedisConn = flag.String("redis", envString("MICROMDM_REDIS_CONN_URL", ""), "redis connection url")
+
+		flVersion = flag.Bool("version", false, "print version information")
+
+		// APNS config. Can be either two files or a combined .p12 (like the one exported from keychain access")
+		flPushCert = flag.String("push-cert", envString("MICROMDM_PUSH_CERT", ""), "path to push certificate")
+		flPushPass = flag.String("push-password", envString("MICROMDM_PUSH_PASSWORD", ""), "push certificate password")
+		flPushKey  = flag.String("push-key", envString("MICROMDM_PUSH_KEY", ""), "path to push certificate private key(if not using a single .p12 file)")
+	)
+	flag.Parse()
+
+	if *flVersion {
+		version.PrintFull()
+		os.Exit(success)
+	}
+
+	config := &Config{}
+	config.loadTLS(*flTLS, *flTLSCert, *flTLSKey)
+	config.loadDEPConfig(*flDEP, *flDEPSim, *flDEPCS, *flDEPCK, *flDEPAT, *flDEPAS, *flDEPServerURL)
+	config.loadServerConfig(*flURL, *flAddress, *flCORSOrigins, *flPkgRepo)
+	config.loadSCEPConfig(*flSCEPURL, *flSCEPChallenge, *flSCEPSubject)
+	config.loadEnrollmentConfig(*flEnrollment, *flServerCAChain)
+	config.loadPostgres(*flPGconn)
+	config.loadRedis(*flRedisConn)
+	config.loadPushConfig(*flPushCert, *flPushKey, *flPushPass)
+	if config.err != nil {
+		return nil, config.err
+	}
+	return config, nil
+}
+
+// Config holds configuration values for MicroMDM. The config values
+// can be loaded from CLI flags or environment variables.
+type Config struct {
+	TLS        *TLSConfig
+	DEP        *DEPConfig
+	SCEP       *SCEPConfig
+	APNS       *PushConfig
+	Enrollment *EnrollmentConfig
+	Redis      *RedisConfig
+	Postgres   *PostgresConfig
+	Server     *ServerConfig
+
+	// the err value is part of the config struct to allow multiple
+	// 'loadConfigFoo' calls in sequence, without checking if err != nil every time.
+	err error
+}
+
+type TLSConfig struct {
+	Enabled         bool
+	CertificatePath string
+	PrivateKeyPath  string
+}
+
+func (c *Config) loadTLS(enabled bool, cert, key string) {
+	if c.err != nil {
+		return
+	}
+	config := &TLSConfig{
+		Enabled:         enabled,
+		CertificatePath: cert,
+		PrivateKeyPath:  key,
+	}
+	if enabled && (cert == "" || key == "") {
+		c.err = errors.New("certificate or key path missing in TLS config")
+		return
+	}
+	c.TLS = config
+}
+
+// DEPConfig holds configuration values for the DEP API.
+// If UseSim is true, the default depsim values will be used instead.
+// When usind depsim, a ServerURL value must be specified.
+type DEPConfig struct {
+	Enabled        bool
+	UseSim         bool
+	ServerURL      string
+	ConsumerKey    string
+	ConsumerSecret string
+	AccessToken    string
+	AccessSecret   string
+}
+
+func (c *Config) loadDEPConfig(enabled, sim bool, ck, cs, at, as, serverURL string) {
+	if c.err != nil {
+		return
+	}
+	config := &DEPConfig{
+		Enabled:        enabled,
+		UseSim:         sim,
+		ConsumerKey:    ck,
+		ConsumerSecret: cs,
+		AccessToken:    at,
+		AccessSecret:   as,
+		ServerURL:      serverURL,
+	}
+	if sim {
+		config.ConsumerKey = "CK_48dd68d198350f51258e885ce9a5c37ab7f98543c4a697323d75682a6c10a32501cb247e3db08105db868f73f2c972bdb6ae77112aea803b9219eb52689d42e6"
+		config.ConsumerSecret = "CS_34c7b2b531a600d99a0e4edcf4a78ded79b86ef318118c2f5bcfee1b011108c32d5302df801adbe29d446eb78f02b13144e323eb9aad51c79f01e50cb45c3a68"
+		config.AccessToken = "AT_927696831c59ba510cfe4ec1a69e5267c19881257d4bca2906a99d0785b785a6f6fdeb09774954fdd5e2d0ad952e3af52c6d8d2f21c924ba0caf4a031c158b89"
+		config.AccessSecret = "AS_c31afd7a09691d83548489336e8ff1cb11b82b6bca13f793344496a556b1f4972eaff4dde6deb5ac9cf076fdfa97ec97699c34d515947b9cf9ed31c99dded6ba"
+	}
+	if sim && serverURL == "" {
+		c.err = errors.New("dep-server-url must be specified when using depsim")
+		return
+	}
+	c.DEP = config
+}
+
+// ServerConfig holds server configuration values.
+// The ListenURL is used for the server listen Addr and the PublicURL
+// is used for embedding the URL in profiles/notification emails etc.
+// The public url is the URL used to connect to micromdm.
+// TODO: PublicURL should be configured via the API/stored in DB.
+type ServerConfig struct {
+	PublicURL       string
+	ListenURL       string
+	CORSOrigins     []string
+	PackageRepoPath string
+}
+
+func (c *Config) loadServerConfig(publicURL, listenURL, cors, repoPath string) {
+	if c.err != nil {
+		return
+	}
+	config := &ServerConfig{
+		PublicURL:       publicURL,
+		ListenURL:       listenURL,
+		CORSOrigins:     strings.Split(cors, ","),
+		PackageRepoPath: repoPath,
+	}
+	if listenURL == "" {
+		config.ListenURL = "0.0.0.0:8080"
+	}
+	if publicURL == "" {
+		config.PublicURL = "127.0.0.1:8080"
+	}
+	c.Server = config
+}
+
+// SCEPConfig holds configuration for the SCEP service.
+// The SCEP service can be either local or remote. If the SCEP service
+// is disabled, a enrollment profile with an identity certificate must be
+// used instead.
+type SCEPConfig struct {
+	Enabled            bool
+	Embedded           bool
+	RemoteURL          string
+	Challenge          string
+	CertificateSubject string
+}
+
+func (c *Config) loadSCEPConfig(remoteURL, challenge, certSubject string) {
+	if c.err != nil {
+		return
+	}
+	config := &SCEPConfig{
+		Enabled:            remoteURL != "",
+		Embedded:           false, // TODO
+		RemoteURL:          remoteURL,
+		Challenge:          challenge,
+		CertificateSubject: certSubject,
+	}
+	c.SCEP = config
+	// FIXME add validation
+}
+
+// EnrollmentConfig holds configuration for enrollment without SCEP.
+// The ProfilePath must point to a .mobileconfig file.
+// An optional path to the server root certificate can also be provided. Use
+// this for adding a trust profile.
+type EnrollmentConfig struct {
+	ProfilePath string // TODO use a template?
+	CACertPath  string
+}
+
+func (c *Config) loadEnrollmentConfig(profile, certChain string) {
+	if c.err != nil {
+		return
+	}
+	config := &EnrollmentConfig{
+		ProfilePath: profile,
+		CACertPath:  certChain,
+	}
+	c.Enrollment = config
+}
+
+type PostgresConfig struct {
+	Enabled    bool
+	Connection string
+}
+
+func (c *Config) loadPostgres(conn string) {
+	if c.err != nil {
+		return
+	}
+	config := &PostgresConfig{
+		Enabled:    true, // currently required.
+		Connection: conn,
+	}
+	if conn == "" {
+		config.fromDockerEnv()
+	}
+	if conn == "" {
+		c.err = errors.New("must provide postgres connection string")
+		return
+	}
+	c.Postgres = config
+}
+
+// FromDockerEnv tries to load postgres connection info from a docker link.
+// The name of the link is assumed to be "postgres".
+// env values taken from https://hub.docker.com/_/postgres/
+func (c *PostgresConfig) fromDockerEnv() {
+	host, ok := os.LookupEnv("POSTGRES_PORT_5432_TCP_ADDR")
+	if !ok {
+		return // don't bother with the rest.
+	}
+	user := os.Getenv("POSTGRES_ENV_POSTGRES_USER")
+	if user == "" {
+		user = "postgres"
+	}
+	dbname := os.Getenv("POSTGRES_ENV_POSTGRES_DB")
+	if dbname == "" {
+		dbname = user //same defaults as the docker pgcontainer
+	}
+	password := os.Getenv("POSTGRES_ENV_POSTGRES_PASSWORD")
+	if password == "" {
+		password = "postgres"
+	}
+	sslmode := os.Getenv("POSTGRES_ENV_SSLMODE")
+	if sslmode == "" {
+		sslmode = "require"
+	}
+	c.Connection = fmt.Sprintf("user=%v password=%v dbname=%v sslmode=%v host=%v", user, password, dbname, sslmode, host)
+}
+
+type RedisConfig struct {
+	Enabled    bool
+	Connection string
+}
+
+func (c *Config) loadRedis(conn string) {
+	if c.err != nil {
+		return
+	}
+	config := &RedisConfig{
+		Enabled:    true, // currently required.
+		Connection: conn,
+	}
+	if conn == "" {
+		config.fromDockerEnv()
+	}
+	if conn == "" {
+		c.err = errors.New("must provide redis connection string")
+		return
+	}
+	c.Redis = config
+}
+
+// FromDockerEnv tries to load connection information from a linked Docker
+// container. The name of the link is assumed to be "redis".
+func (c *RedisConfig) fromDockerEnv() {
+	host, ok := os.LookupEnv("REDIS_PORT_6379_TCP_ADDR")
+	if !ok {
+		return
+	}
+	port := os.Getenv("REDIS_PORT_6379_TCP_PORT")
+	c.Connection = fmt.Sprintf("%v:%v", host, port)
+}
+
+// PushConfig holds values for connecting to APNS. The private key can be either
+// a PEM or a p12 file.
+type PushConfig struct {
+	CertificatePath string
+	PrivateKeyPath  string
+	PrivateKeyPass  string
+}
+
+func (c *Config) loadPushConfig(certPath, keyPath, keyPassword string) {
+	if c.err != nil {
+		return
+	}
+	config := &PushConfig{
+		CertificatePath: certPath,
+		PrivateKeyPath:  keyPath,
+		PrivateKeyPass:  keyPassword,
+	}
+	if certPath == "" {
+		c.err = errors.New("must provide MDM push certificate")
+		return
+	}
+	c.APNS = config
+}

--- a/app/envutils.go
+++ b/app/envutils.go
@@ -3,7 +3,7 @@ package app
 import "os"
 
 func envString(key, def string) string {
-	if env := os.Getenv(key); env != "" {
+	if env, ok := os.LookupEnv(key); ok {
 		return env
 	}
 	return def

--- a/app/envutils.go
+++ b/app/envutils.go
@@ -1,0 +1,17 @@
+package app
+
+import "os"
+
+func envString(key, def string) string {
+	if env := os.Getenv(key); env != "" {
+		return env
+	}
+	return def
+}
+
+func envBool(key string) bool {
+	if env := os.Getenv(key); env == "true" {
+		return true
+	}
+	return false
+}

--- a/app/http.go
+++ b/app/http.go
@@ -1,0 +1,98 @@
+package app
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+
+	"github.com/go-kit/kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rs/cors"
+	"golang.org/x/net/context"
+
+	"github.com/micromdm/micromdm/checkin"
+	"github.com/micromdm/micromdm/command"
+	"github.com/micromdm/micromdm/connect"
+	"github.com/micromdm/micromdm/enroll"
+	"github.com/micromdm/micromdm/management"
+	"github.com/micromdm/micromdm/version"
+)
+
+func makeHTTPHandler(logger log.Logger, sm *serviceManager) http.Handler {
+	httpLogger := log.NewContext(logger).With("component", "http")
+	ctx := context.Background()
+
+	mgmtHandler := management.ServiceHandler(ctx, sm.ManagementService, httpLogger)
+	commandHandler := command.ServiceHandler(ctx, sm.CommandService, httpLogger)
+	checkinHandler := checkin.ServiceHandler(ctx, sm.CheckinService, httpLogger)
+	connectHandler := connect.ServiceHandler(ctx, sm.ConnectService, httpLogger)
+	enrollHandler := enroll.ServiceHandler(ctx, sm.EnrollmentService, httpLogger)
+
+	var handler http.Handler
+	mux := http.NewServeMux()
+	mux.Handle("/management/v1/", mgmtHandler)
+	mux.Handle("/mdm/commands", commandHandler)
+	mux.Handle("/mdm/commands/", commandHandler)
+	mux.Handle("/mdm/checkin", checkinHandler)
+	mux.Handle("/mdm/connect", connectHandler)
+	mux.Handle("/mdm/enroll", enrollHandler)
+	mux.Handle("/_metrics", prometheus.Handler())
+	mux.Handle("/_version", version.Handler())
+	if sm.Server.PackageRepoPath != "" {
+		pkgrepoHandler := http.StripPrefix("/repo/",
+			http.FileServer(http.Dir(sm.Server.PackageRepoPath)),
+		)
+		mux.Handle("/repo/", pkgrepoHandler)
+	}
+	handler = mux
+
+	if len(sm.Server.CORSOrigins) > 0 {
+		handler = cors.New(cors.Options{
+			AllowedOrigins:   sm.Server.CORSOrigins,
+			AllowCredentials: true,
+			AllowedMethods:   []string{"GET", "POST", "PATCH", "DELETE"},
+		}).Handler(mux)
+	}
+
+	return handler
+}
+
+func serveHTTP(logger log.Logger, h http.Handler, tlsEnabled bool, httpAddr, keyPath, certPath string) error {
+	if tlsEnabled {
+		if err := verifyTLSCerts(certPath, keyPath); err != nil {
+			return err
+		}
+
+		logger.Log("msg", "serving https", "addr", httpAddr)
+		return http.ListenAndServeTLS(httpAddr, certPath, keyPath, h)
+	} else {
+		logger.Log("msg", "serving http", "addr", httpAddr)
+		return http.ListenAndServe(httpAddr, h)
+	}
+}
+
+func verifyTLSCerts(certPath, keyPath string) error {
+	chain, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		return fmt.Errorf("serve: failed to load TLS cert or private key: %s", err)
+	}
+
+	cert, err := x509.ParseCertificate(chain.Certificate[0]) // Leaf is always the first entry
+	if err != nil {
+		return fmt.Errorf("server: error parsing TLS certificate: %s", err)
+	}
+
+	if _, err := cert.Verify(x509.VerifyOptions{}); err != nil {
+		switch e := err.(type) {
+		case x509.CertificateInvalidError:
+			switch e.Reason {
+			case x509.Expired:
+				return fmt.Errorf("server certificate has expired: %s", err)
+			default:
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/app/services.go
+++ b/app/services.go
@@ -1,0 +1,230 @@
+package app
+
+import (
+	"io/ioutil"
+
+	pushcertificate "github.com/RobotsAndPencils/buford/certificate"
+	"github.com/RobotsAndPencils/buford/push"
+	"github.com/go-kit/kit/log"
+
+	"github.com/micromdm/dep"
+	"github.com/micromdm/micromdm/application"
+	"github.com/micromdm/micromdm/certificate"
+	"github.com/micromdm/micromdm/checkin"
+	"github.com/micromdm/micromdm/command"
+	"github.com/micromdm/micromdm/connect"
+	"github.com/micromdm/micromdm/device"
+	"github.com/micromdm/micromdm/enroll"
+	"github.com/micromdm/micromdm/management"
+	"github.com/micromdm/micromdm/workflow"
+)
+
+// setupServices uses the values from the config to set up the various components
+// which MicroMDM relies on.
+func setupServices(config *Config, logger log.Logger) (*serviceManager, error) {
+	sm := &serviceManager{Config: config, logger: logger}
+	sm.setupAppDatastore()
+	sm.setupDeviceDatastore()
+	sm.setupWorkflowDatastore()
+	sm.setupCertificateDatastore()
+
+	sm.setupPushService()
+
+	sm.setupCommandService()
+	sm.setupManagementService()
+	sm.setupCheckinService()
+	sm.setupConnectService()
+	sm.setupEnrollmentService()
+	if sm.err != nil {
+		return nil, sm.err
+	}
+	return sm, nil
+}
+
+// serviceManager knows how to setup the independent components which make up
+// MicroMDM, mainly Datastores and Services.
+type serviceManager struct {
+	CommandDatastore     command.Datastore
+	CertificateDatastore certificate.Datastore
+	DeviceDatastore      device.Datastore
+	WorkflowDatastore    workflow.Datastore
+	ApplicationDatastore application.Datastore
+
+	PushService *push.Service
+
+	CommandService    command.Service
+	ManagementService management.Service
+	CheckinService    checkin.Service
+	ConnectService    connect.Service
+	EnrollmentService enroll.Service
+
+	*Config
+	logger log.Logger
+	err    error
+}
+
+func (s *serviceManager) setupEnrollmentService() {
+	if s.err != nil {
+		return
+	}
+	// TODO: clean up order of inputs. Maybe pass *SCEPConfig as an arg?
+	// but if you do, the packages are coupled, better not.
+	s.EnrollmentService, s.err = enroll.NewService(
+		s.APNS.CertificatePath,
+		s.APNS.PrivateKeyPass,
+		s.Enrollment.CACertPath,
+		s.SCEP.RemoteURL,
+		s.SCEP.Challenge,
+		s.Server.PublicURL,
+		s.TLS.CertificatePath,
+		s.SCEP.CertificateSubject,
+	)
+}
+
+func (s *serviceManager) setupConnectService() {
+	if s.err != nil {
+		return
+	}
+	s.ConnectService = connect.NewService(
+		s.DeviceDatastore,
+		s.ApplicationDatastore,
+		s.CertificateDatastore,
+		s.CommandService,
+	)
+}
+
+func (s *serviceManager) setupCheckinService() {
+	if s.err != nil {
+		return
+	}
+	var enrollmentProfile []byte
+	// TODO make this optional - checkin.WithEnrollmentProfile([]byte)
+	if s.DEP.Enabled {
+		enrollmentProfile, s.err = ioutil.ReadFile(s.Enrollment.ProfilePath)
+		if s.err != nil {
+			return
+		}
+	}
+
+	s.CheckinService = checkin.NewService(
+		s.DeviceDatastore,
+		s.ManagementService,
+		s.CommandService,
+		enrollmentProfile,
+	)
+
+}
+
+func (s *serviceManager) setupManagementService() {
+	if s.err != nil {
+		return
+	}
+	var client dep.Client
+	if s.DEP.Enabled {
+		var opts []func(*dep.Config) error
+		config := &dep.Config{
+			ConsumerKey:    s.DEP.ConsumerKey,
+			ConsumerSecret: s.DEP.ConsumerSecret,
+			AccessToken:    s.DEP.AccessToken,
+			AccessSecret:   s.DEP.AccessSecret,
+		}
+		if s.DEP.UseSim {
+			opts = append(opts, dep.ServerURL(s.DEP.ServerURL))
+		}
+		client, s.err = dep.NewClient(config, opts...)
+		if s.err != nil {
+			return
+		}
+	}
+	s.ManagementService = management.NewService(
+		s.DeviceDatastore,
+		s.WorkflowDatastore,
+		client,
+		s.PushService,
+		s.ApplicationDatastore,
+		s.CertificateDatastore,
+	)
+}
+
+func (s *serviceManager) setupPushService() {
+	if s.err != nil {
+		return
+	}
+	cert, key, err := pushcertificate.Load(s.APNS.CertificatePath, s.APNS.PrivateKeyPass)
+	if err != nil {
+		s.err = err
+		return
+	}
+	client, err := push.NewClient(pushcertificate.TLS(cert, key))
+	if err != nil {
+		s.err = err
+		return
+	}
+	s.PushService = &push.Service{
+		Client: client,
+		Host:   push.Production,
+	}
+
+}
+
+func (s *serviceManager) setupCertificateDatastore() {
+	if s.err != nil {
+		return
+	}
+	db, err := certificate.NewDB("postgres", s.Postgres.Connection, s.logger)
+	if err != nil {
+		s.err = err
+		return
+	}
+	s.CertificateDatastore = db
+}
+
+func (s *serviceManager) setupAppDatastore() {
+	if s.err != nil {
+		return
+	}
+	db, err := application.NewDB("postgres", s.Postgres.Connection, s.logger)
+	if err != nil {
+		s.err = err
+		return
+	}
+	s.ApplicationDatastore = db
+}
+
+func (s *serviceManager) setupWorkflowDatastore() {
+	if s.err != nil {
+		return
+	}
+	db, err := workflow.NewDB("postgres", s.Postgres.Connection, s.logger)
+	if err != nil {
+		s.err = err
+		return
+	}
+	s.WorkflowDatastore = db
+}
+
+func (s *serviceManager) setupDeviceDatastore() {
+	if s.err != nil {
+		return
+	}
+	db, err := device.NewDB("postgres", s.Postgres.Connection, s.logger)
+	if err != nil {
+		s.err = err
+		return
+	}
+	s.DeviceDatastore = db
+}
+
+func (s *serviceManager) setupCommandService() {
+	if s.err != nil {
+		return
+	}
+	db, err := command.NewDB("redis", s.Redis.Connection, s.logger)
+	if err != nil {
+		s.err = err
+		return
+	}
+	s.CommandDatastore = db
+	s.CommandService = command.NewService(db)
+	return
+}

--- a/cli/main.go
+++ b/cli/main.go
@@ -1,0 +1,23 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/micromdm/micromdm/version"
+)
+
+func Main() {
+	switch os.Args[1] {
+	case "version":
+		version.Print()
+		return
+	case "gencert":
+		fmt.Printf("coming soon\n")
+		return
+	default:
+		fmt.Printf("no such command")
+		return
+	}
+
+}

--- a/enroll/transport.go
+++ b/enroll/transport.go
@@ -12,7 +12,7 @@ import (
 )
 
 // ServiceHandler returns an HTTP Handler for the enroll service
-func MakeHTTPHandler(ctx context.Context, svc Service, logger log.Logger) http.Handler {
+func ServiceHandler(ctx context.Context, svc Service, logger log.Logger) http.Handler {
 	r := mux.NewRouter()
 	e := MakeServerEndpoints(svc)
 	opts := []httptransport.ServerOption{

--- a/main.go
+++ b/main.go
@@ -3,19 +3,25 @@ package main
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"database/sql"
 	"errors"
 	"flag"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
+	"time"
 
-	"database/sql"
 	"github.com/DavidHuie/gomigrate"
 	"github.com/RobotsAndPencils/buford/certificate"
 	"github.com/RobotsAndPencils/buford/push"
 	"github.com/go-kit/kit/log"
+	stdprometheus "github.com/prometheus/client_golang/prometheus"
+	"github.com/rs/cors"
+	"golang.org/x/net/context"
+
 	"github.com/micromdm/dep"
+	"github.com/micromdm/micromdm/app"
 	"github.com/micromdm/micromdm/application"
 	mdmCert "github.com/micromdm/micromdm/certificate"
 	"github.com/micromdm/micromdm/checkin"
@@ -25,10 +31,6 @@ import (
 	"github.com/micromdm/micromdm/enroll"
 	"github.com/micromdm/micromdm/management"
 	"github.com/micromdm/micromdm/workflow"
-	stdprometheus "github.com/prometheus/client_golang/prometheus"
-	"github.com/rs/cors"
-	"golang.org/x/net/context"
-	"time"
 )
 
 var (
@@ -38,6 +40,10 @@ var (
 )
 
 func main() {
+	os.Exit(app.Main())
+}
+
+func mainDeprecated() {
 	ctx := context.Background()
 	logger := log.NewLogfmtLogger(os.Stderr)
 

--- a/main.go
+++ b/main.go
@@ -1,443 +1,64 @@
 package main
 
 import (
-	"crypto/tls"
-	"crypto/x509"
-	"database/sql"
-	"errors"
-	"flag"
 	"fmt"
-	"io/ioutil"
-	"net/http"
+	stdlog "log"
+	"math/rand"
 	"os"
+	"os/signal"
+	"strings"
+	"syscall"
 	"time"
 
-	"github.com/DavidHuie/gomigrate"
-	"github.com/RobotsAndPencils/buford/certificate"
-	"github.com/RobotsAndPencils/buford/push"
 	"github.com/go-kit/kit/log"
-	stdprometheus "github.com/prometheus/client_golang/prometheus"
-	"github.com/rs/cors"
-	"golang.org/x/net/context"
 
-	"github.com/micromdm/dep"
 	"github.com/micromdm/micromdm/app"
-	"github.com/micromdm/micromdm/application"
-	mdmCert "github.com/micromdm/micromdm/certificate"
-	"github.com/micromdm/micromdm/checkin"
-	"github.com/micromdm/micromdm/command"
-	"github.com/micromdm/micromdm/connect"
-	"github.com/micromdm/micromdm/device"
-	"github.com/micromdm/micromdm/enroll"
-	"github.com/micromdm/micromdm/management"
-	"github.com/micromdm/micromdm/workflow"
-)
-
-var (
-	// Version info
-	Version = "unreleased"
-	gitHash = "unknown"
+	"github.com/micromdm/micromdm/cli"
 )
 
 func main() {
-	os.Exit(app.Main())
-}
+	if isCLI() { // use CLI if the user typed a subcommand.
+		cli.Main()
+		return
+	}
 
-func mainDeprecated() {
-	ctx := context.Background()
 	logger := log.NewLogfmtLogger(os.Stderr)
+	stdlog.SetOutput(log.NewStdlibAdapter(logger)) // force structured logs
+	mainLogger := log.NewContext(logger).With("component", "main")
 
-	//flags
-	var (
-		flURL           = flag.String("url", envString("MICROMDM_URL", ""), "public facing url")
-		flPort          = flag.String("port", envString("MICROMDM_HTTP_LISTEN_PORT", ""), "port to listen on")
-		flTLS           = flag.Bool("tls", envBool("MICROMDM_USE_TLS"), "use https")
-		flTLSCert       = flag.String("tls-cert", envString("MICROMDM_TLS_CERT", ""), "path to TLS certificate")
-		flTLSKey        = flag.String("tls-key", envString("MICROMDM_TLS_KEY", ""), "path to TLS private key")
-		flTLSCACert     = flag.String("tls-ca-cert", envString("MICROMDM_TLS_CA_CERT", ""), "path to CA certificate")
-		flSCEPURL       = flag.String("scep-url", envString("MICROMDM_SCEP_URL", ""), "scep server url. If blank, enroll profile will not use a scep payload.")
-		flSCEPChallenge = flag.String("scep-challenge", envString("MICROMDM_SCEP_CHALLENGE", ""), "scep server challenge")
-		flSCEPSubject   = flag.String("scep-subject", envString("MICROMDM_SCEP_SUBJECT", ""), "scep request subject in microsoft string representation")
-		flPGconn        = flag.String("postgres", envString("MICROMDM_POSTGRES_CONN_URL", ""), "postgres connection url")
-		flRedisconn     = flag.String("redis", envString("MICROMDM_REDIS_CONN_URL", ""), "redis connection url")
-		flVersion       = flag.Bool("version", false, "print version information")
-		flPushCert      = flag.String("push-cert", envString("MICROMDM_PUSH_CERT", ""), "path to push certificate")
-		flPushPass      = flag.String("push-pass", envString("MICROMDM_PUSH_PASS", ""), "push certificate password")
-		flEnrollment    = flag.String("profile", envString("MICROMDM_ENROLL_PROFILE", ""), "path to enrollment profile")
-		flDEP           = flag.Bool("dep", envBool("MICROMDM_USE_DEP"), "use DEP")
-		flDEPCK         = flag.String("dep-consumer-key", envString("DEP_CONSUMER_KEY", ""), "dep consumer key")
-		flDEPCS         = flag.String("dep-consumer-secret", envString("DEP_CONSUMER_SECRET", ""), "dep consumer secret")
-		flDEPAT         = flag.String("dep-access-token", envString("DEP_ACCESS_TOKEN", ""), "dep access token")
-		flDEPAS         = flag.String("dep-access-secret", envString("DEP_ACCESS_SECRET", ""), "dep access secret")
-		flDEPsim        = flag.Bool("depsim", envBool("DEP_USE_DEPSIM"), "use default depsim credentials")
-		flDEPServerURL  = flag.String("dep-server-url", envString("DEP_SERVER_URL", ""), "dep server url. for testing. Use blank if not running against depsim")
-		flPkgRepo       = flag.String("pkg-repo", envString("MICROMDM_PKG_REPO", ""), "path to pkg repo")
-		flCORSOrigin    = flag.String("cors-origin", envString("MICROMDM_CORS_ORIGIN", ""), "allowed domain for cross origin resource sharing")
-	)
-
-	// set tls to true by default. let user set it to false
-	*flTLS = true
-	flag.Parse()
-
-	// -version flag
-	if *flVersion {
-		fmt.Printf("micromdm - Version %s\n", Version)
-		fmt.Printf("Git Hash - %s\n", gitHash)
-		os.Exit(0)
-	}
-
-	// check port flag
-	// if none is provided, default to 80 or 443
-	if *flPort == "" {
-		port := defaultPort(*flTLS)
-		logger.Log("msg", fmt.Sprintf("No port flag specified. Using %v by default", port))
-		*flPort = port
-	}
-
-	if *flEnrollment == "" {
-		logger.Log("err", "must set path to enrollment profile")
-		os.Exit(1)
-	}
-	enrollmentProfile, err := ioutil.ReadFile(*flEnrollment)
-	if err != nil {
-		logger.Log("err", err)
-		os.Exit(1)
-	}
-
-	// check cert and key if -tls=true
-	if *flTLS {
-		if err := checkTLSFlags(*flTLSKey, *flTLSCert); err != nil {
-			logger.Log("err", err)
-			os.Exit(1)
+	// the default action for no subcommand is to launch the server.
+	errs := make(chan error, 2)
+	go func() {
+		c := make(chan os.Signal)
+		signal.Notify(c, syscall.SIGINT)
+		errs <- fmt.Errorf("%s", <-c)
+	}()
+	go func() {
+		status, err := app.Main(logger)
+		if err != nil {
+			mainLogger.Log("terminated", err)
 		}
-	}
-
-	pgHostAddr := os.Getenv("POSTGRES_PORT_5432_TCP_ADDR")
-	if *flPGconn == "" && pgHostAddr != "" {
-		*flPGconn = getPGConnFromENV(logger, pgHostAddr)
-	}
-
-	// check database connection
-	if *flPGconn == "" {
-		logger.Log("err", "database connection url not specified")
-		os.Exit(1)
-	}
-	if checkEmptyArgs(*flPushCert, *flPushPass) {
-		logger.Log("err", "must specify push cert path and password")
-		os.Exit(1)
-	}
-
-	pushSvc, err := pushService(*flPushCert, *flPushPass)
-	if err != nil {
-		logger.Log("err", err)
-		os.Exit(1)
-	}
-
-	// Run migrations
-	db, err := sql.Open("postgres", *flPGconn)
-	if err != nil {
-		logger.Log("err", err)
-		os.Exit(1)
-	}
-	var dbError error
-	maxAttempts := 20
-	for attempts := 1; attempts <= maxAttempts; attempts++ {
-		dbError = db.Ping()
-		if dbError == nil {
-			break
-		}
-		logger.Log("msg", fmt.Sprintf("could not connect to postgres: %v", dbError))
-		time.Sleep(time.Duration(attempts) * time.Second)
-	}
-	if dbError != nil {
-		logger.Log("err", dbError)
-		os.Exit(1)
-	}
-
-	migrator, _ := gomigrate.NewMigrator(db, gomigrate.Postgres{}, "./migrations")
-	migrationErr := migrator.Migrate()
-
-	if migrationErr != nil {
-		logger.Log("err", err)
-		os.Exit(1)
-	}
-
-	workflowDB, err := workflow.NewDB(
-		"postgres",
-		*flPGconn,
-		logger,
-	)
-	if err != nil {
-		logger.Log("err", err)
-		os.Exit(1)
-	}
-
-	deviceDB, err := device.NewDB(
-		"postgres",
-		*flPGconn,
-		logger,
-	)
-	if err != nil {
-		logger.Log("err", err)
-		os.Exit(1)
-	}
-
-	redisHostAddr := os.Getenv("REDIS_PORT_6379_TCP_ADDR")
-	if *flRedisconn == "" && redisHostAddr != "" {
-		*flRedisconn = getRedisConnFromENV(redisHostAddr)
-	}
-
-	// check database connection
-	if *flRedisconn == "" {
-		logger.Log("err", "database connection url not specified")
-		os.Exit(1)
-	}
-
-	commandDB, err := command.NewDB("redis", *flRedisconn, logger)
-	if err != nil {
-		logger.Log("err", err)
-		os.Exit(1)
-	}
-
-	appsDB, err := application.NewDB(
-		"postgres",
-		*flPGconn,
-		logger,
-	)
-	if err != nil {
-		logger.Log("err", err)
-		os.Exit(1)
-	}
-
-	certsDB, err := mdmCert.NewDB(
-		"postgres",
-		*flPGconn,
-		logger,
-	)
-	if err != nil {
-		logger.Log("err", err)
-		os.Exit(1)
-	}
-
-	var mgmtSvc management.Service
-	if *flDEP == true {
-		logger.Log("info", "DEP support enabled")
-		dc := depClient(logger, *flDEPCK, *flDEPCS, *flDEPAT, *flDEPAS, *flDEPServerURL, *flDEPsim)
-		mgmtSvc = management.NewService(deviceDB, workflowDB, dc, pushSvc, appsDB, certsDB)
-	} else {
-		logger.Log("info", "DEP support disabled")
-		mgmtSvc = management.NewService(deviceDB, workflowDB, nil, pushSvc, appsDB, certsDB)
-
-	}
-
-	commandSvc := command.NewService(commandDB)
-	checkinSvc := checkin.NewService(deviceDB, mgmtSvc, commandSvc, enrollmentProfile)
-	connectSvc := connect.NewService(deviceDB, appsDB, certsDB, commandSvc)
-
-	httpLogger := log.NewContext(logger).With("component", "http")
-	managementHandler := management.ServiceHandler(ctx, mgmtSvc, httpLogger)
-	commandHandler := command.ServiceHandler(ctx, commandSvc, httpLogger)
-	checkinHandler := checkin.ServiceHandler(ctx, checkinSvc, httpLogger)
-	connectHandler := connect.ServiceHandler(ctx, connectSvc, httpLogger)
-
-	mux := http.NewServeMux()
-
-	mux.Handle("/management/v1/", managementHandler)
-	mux.Handle("/mdm/commands", commandHandler)
-	mux.Handle("/mdm/commands/", commandHandler)
-	mux.Handle("/mdm/checkin", checkinHandler)
-	mux.Handle("/mdm/connect", connectHandler)
-
-	if checkEmptyArgs(*flURL, *flSCEPURL) {
-		logger.Log("warn", "Enrollment endpoint /mdm/enroll will be disabled because you did not specify flags/environment vars for the external URL (--url MICROMDM_URL) or SCEP URL (--scep-url/MICROMDM_SCEP_URL)")
-	} else {
-		if *flSCEPChallenge == "" {
-			logger.Log("warn", "You did not specify a SCEP challenge via --scep-challenge or MICROMDM_SCEP_CHALLENGE (this may not be what you intended, the user will be prompted for a challenge).")
-		}
-
-		if *flTLSCACert == "" {
-			logger.Log("warn", "You did not specify a CA Certificate to trust via --tls-ca-cert or MICROMDM_TLS_CA_CERT. If your certificates are self signed, devices may not be able to enroll.")
-		}
-		enrollSvc, _ := enroll.NewService(*flPushCert, *flPushPass, *flTLSCACert, *flSCEPURL, *flSCEPChallenge, *flURL, *flTLSCert, *flSCEPSubject)
-		enrollHandler := enroll.MakeHTTPHandler(ctx, enrollSvc, httpLogger)
-		mux.Handle("/mdm/enroll", enrollHandler)
-	}
-
-	if *flPkgRepo != "" {
-		mux.Handle("/repo/", http.StripPrefix("/repo/", http.FileServer(http.Dir(*flPkgRepo))))
-	}
-
-	if *flCORSOrigin != "" {
-		c := cors.New(cors.Options{
-			AllowedOrigins:   []string{*flCORSOrigin},
-			AllowCredentials: true,
-			AllowedMethods:   []string{"GET", "POST", "PATCH", "DELETE"},
-		})
-
-		corsHandler := c.Handler(mux)
-		http.Handle("/", corsHandler)
-	} else {
-		logger.Log("warn", "CORS header is disabled")
-		http.Handle("/", mux)
-	}
-
-	http.Handle("/metrics", stdprometheus.Handler())
-
-	serve(logger, *flTLS, *flPort, *flTLSKey, *flTLSCert)
+		os.Exit(status)
+	}()
+	mainLogger.Log("terminated", <-errs)
 }
 
-func depClient(logger log.Logger, consumerKey, consumerSecret, accessToken, accessSecret, serverURL string, depsim bool) dep.Client {
-	var config *dep.Config
-	if depsim {
-		config = &dep.Config{
-			ConsumerKey:    "CK_48dd68d198350f51258e885ce9a5c37ab7f98543c4a697323d75682a6c10a32501cb247e3db08105db868f73f2c972bdb6ae77112aea803b9219eb52689d42e6",
-			ConsumerSecret: "CS_34c7b2b531a600d99a0e4edcf4a78ded79b86ef318118c2f5bcfee1b011108c32d5302df801adbe29d446eb78f02b13144e323eb9aad51c79f01e50cb45c3a68",
-			AccessToken:    "AT_927696831c59ba510cfe4ec1a69e5267c19881257d4bca2906a99d0785b785a6f6fdeb09774954fdd5e2d0ad952e3af52c6d8d2f21c924ba0caf4a031c158b89",
-			AccessSecret:   "AS_c31afd7a09691d83548489336e8ff1cb11b82b6bca13f793344496a556b1f4972eaff4dde6deb5ac9cf076fdfa97ec97699c34d515947b9cf9ed31c99dded6ba",
-		}
-	} else {
-		if checkEmptyArgs(consumerKey, consumerSecret, accessToken, accessSecret) {
-			logger.Log("err", "must specify DEP server credentials")
-			logger.Log("ConsumerKey", consumerKey, "ConsumerSecret", consumerSecret, "AccessToken", accessToken, "AccessSecret", accessSecret)
-			os.Exit(1)
-		}
-		config = &dep.Config{
-			ConsumerKey:    consumerKey,
-			ConsumerSecret: consumerSecret,
-			AccessToken:    accessToken,
-			AccessSecret:   accessSecret,
-		}
-	}
-	var client dep.Client
-	var err error
-	if serverURL != "" {
-		client, err = dep.NewClient(config, dep.ServerURL(serverURL))
-	} else {
-		client, err = dep.NewClient(config)
-	}
-	if err != nil {
-		logger.Log("err", err)
-		os.Exit(1)
-	}
-
-	return client
+func init() {
+	rand.Seed(time.Now().UnixNano())
 }
 
-func pushService(certPath, password string) (*push.Service, error) {
-	cert, key, err := certificate.Load(certPath, password)
-	if err != nil {
-		return nil, err
-	}
-	client, err := push.NewClient(certificate.TLS(cert, key))
-	if err != nil {
-		return nil, err
-	}
-	service := &push.Service{
-		Client: client,
-		Host:   push.Production,
-	}
-
-	return service, nil
-}
-
-func checkEmptyArgs(args ...string) bool {
-	for _, arg := range args {
-		if arg == "" {
+// isCLI determines if this is the default app or if there are subcommands.
+// ./micromdm or ./micromdm -foo would return false, while ./micromdm version
+// would return true
+func isCLI() bool {
+	switch len(os.Args) {
+	case 1:
+		return false
+	default:
+		if strings.HasPrefix(os.Args[1], "-") {
+			return false
+		} else {
 			return true
 		}
 	}
-	return false
-}
-
-// choose http or https
-func serve(logger log.Logger, tlsEnabled bool, port, key, certPath string) {
-	portStr := fmt.Sprintf(":%v", port)
-	if tlsEnabled {
-		chain, err := tls.LoadX509KeyPair(certPath, key)
-		if err != nil {
-			logger.Log("err", "failed to load TLS certificate or private key")
-			os.Exit(1)
-		}
-
-		cert, err := x509.ParseCertificate(chain.Certificate[0]) // Leaf is always the first entry
-		if err != nil {
-			logger.Log("err", "error parsing TLS certificate")
-			os.Exit(1)
-		}
-
-		if _, err := cert.Verify(x509.VerifyOptions{}); err != nil {
-			switch e := err.(type) {
-			case x509.CertificateInvalidError:
-				switch e.Reason {
-				case x509.Expired:
-					logger.Log("err", "certificate has expired")
-				default:
-					logger.Log("err", "certificate is invalid")
-				}
-			}
-		}
-
-		logger.Log("msg", "HTTPs", "addr", port)
-		logger.Log("err", http.ListenAndServeTLS(portStr, certPath, key, nil))
-	} else {
-		logger.Log("msg", "HTTP", "addr", port)
-		logger.Log("err", http.ListenAndServe(portStr, nil))
-	}
-}
-
-func envString(key, def string) string {
-	if env := os.Getenv(key); env != "" {
-		return env
-	}
-	return def
-}
-
-func envBool(key string) bool {
-	if env := os.Getenv(key); env == "true" {
-		return true
-	}
-	return false
-}
-
-func checkTLSFlags(key, cert string) error {
-	if key == "" || cert == "" {
-		return errors.New("You must provide a valid path to a TLS cert and key")
-	}
-	return nil
-}
-
-func defaultPort(tls bool) string {
-	if tls {
-		return "443"
-	}
-	return "80"
-}
-
-// use this in docker container
-func getPGConnFromENV(logger log.Logger, host string) string {
-	user := os.Getenv("POSTGRES_ENV_POSTGRES_USER")
-	if user == "" {
-		user = "postgres"
-	}
-	dbname := os.Getenv("POSTGRES_ENV_POSTGRES_DB")
-	if dbname == "" {
-		dbname = user //same defaults as the docker pgcontainer
-	}
-	password := os.Getenv("POSTGRES_ENV_POSTGRES_PASSWORD")
-	if password == "" {
-		password = "postgres"
-	}
-	sslmode := os.Getenv("POSTGRES_ENV_SSLMODE")
-	if sslmode == "" {
-		logger.Log("msg", "POSTGRES_ENV_SSLMODE not specified, using 'require' by default")
-		sslmode = "require"
-	}
-	conn := fmt.Sprintf("user=%v password=%v dbname=%v sslmode=%v host=%v", user, password, dbname, sslmode, host)
-	return conn
-}
-
-func getRedisConnFromENV(host string) string {
-	port := os.Getenv("REDIS_PORT_6379_TCP_PORT")
-	conn := fmt.Sprintf("%v:%v", host, port)
-	return conn
 }

--- a/release.sh
+++ b/release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION="0.1.0.1-dev"
+VERSION="0.1.2.0-dev"
 NAME=micromdm
 
 echo "Building $NAME version $VERSION"
@@ -9,7 +9,12 @@ mkdir -p build
 
 build() {
   echo -n "=> $1-$2: "
-  GOOS=$1 GOARCH=$2 CGO_ENABLED=0 go build -o build/$NAME-$1-$2 -ldflags "-X main.Version=$VERSION -X main.gitHash=`git rev-parse HEAD`" ./main.go
+  GOOS=$1 GOARCH=$2 CGO_ENABLED=0 go build -o build/$NAME-$1-$2 -ldflags "\
+      -X github.com/micromdm/micromdm/version.version=${VERSION} \
+      -X github.com/micromdm/micromdm/version.gitBranch=$(git rev-parse --abbrev-ref HEAD) \
+      -X github.com/micromdm/micromdm/version.goVersion=$(go version | awk '{print $3}') \
+      -X github.com/micromdm/micromdm/version.buildTime=$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
+      -X github.com/micromdm/micromdm/version.gitRev=$(git rev-parse HEAD)" ./main.go
   du -h build/$NAME-$1-$2
 }
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,68 @@
+// Package version provides utilities for managing and printing the current
+// version of the MicroMDM binary.
+package version
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// version flags are set at build time with the go build tool.
+// example:
+// go build -ldflags "-X github.com/micromdm/micromdm/version.version=v1.0.0-dev"
+var (
+	version   = "unknown"
+	gitBranch = "unknown"
+	gitRev    = "unknown"
+	goVersion = "unknown"
+	buildTime = "unknown"
+)
+
+// Info holds version and build info for the current MicroMDM binary.
+type Info struct {
+	Version   string `json:"version"`
+	Branch    string `json:"branch"`
+	Revision  string `json:"revision"`
+	GoVersion string `json:"go_version"`
+	BuildDate string `json:"build_date"`
+}
+
+// Version returns a struct with the current version information.
+func Version() Info {
+	return Info{
+		Version:   version,
+		Branch:    gitBranch,
+		Revision:  gitRev,
+		GoVersion: goVersion,
+		BuildDate: buildTime,
+	}
+}
+
+// Print outputs the app name and version string.
+func Print() {
+	v := Version()
+	fmt.Printf("MicroMDM - version %s\n", v.Version)
+}
+
+// PrintFull outputs the app name and detailed version information.
+func PrintFull() {
+	v := Version()
+	fmt.Printf("MicroMDM - version %s\n", v.Version)
+	fmt.Printf("  branch: \t%s\n", v.Branch)
+	fmt.Printf("  revision: \t%s\n", v.Revision)
+	fmt.Printf("  build date: \t%s\n", v.BuildDate)
+	fmt.Printf("  go version: \t%s\n", v.GoVersion)
+}
+
+// Handler provides an HTTP Handler that returns JSON formatted version info.
+func Handler() http.Handler {
+	v := Version()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		enc.Encode(v)
+
+	})
+}


### PR DESCRIPTION
Add a config struct and parse CLI flags outside of main.main.

I'm updating the main package because it's gotten long and can be refactored to be more consistent/easier to add to in the future. 