### PR TITLE
add event publisher

### DIFF
--- a/app/config.go
+++ b/app/config.go
@@ -142,6 +142,9 @@ func (c *Config) loadDEPConfig(enabled, sim bool, ck, cs, at, as, serverURL stri
 		AccessSecret:   as,
 		ServerURL:      serverURL,
 	}
+	if !sim && (ck == "" || cs == "" || at == "" || as == "") {
+		config.Enabled = false
+	}
 	if sim {
 		config.ConsumerKey = "CK_48dd68d198350f51258e885ce9a5c37ab7f98543c4a697323d75682a6c10a32501cb247e3db08105db868f73f2c972bdb6ae77112aea803b9219eb52689d42e6"
 		config.ConsumerSecret = "CS_34c7b2b531a600d99a0e4edcf4a78ded79b86ef318118c2f5bcfee1b011108c32d5302df801adbe29d446eb78f02b13144e323eb9aad51c79f01e50cb45c3a68"
@@ -294,15 +297,13 @@ func (c *Config) loadRedis(conn string) {
 		return
 	}
 	config := &RedisConfig{
-		Enabled:    true, // currently required.
 		Connection: conn,
 	}
 	if conn == "" {
 		config.fromDockerEnv()
 	}
-	if conn == "" {
-		c.err = errors.New("must provide redis connection string")
-		return
+	if conn != "" {
+		config.Enabled = true
 	}
 	c.Redis = config
 }

--- a/checkin/archive/archive.go
+++ b/checkin/archive/archive.go
@@ -1,0 +1,112 @@
+package archive
+
+import (
+	"fmt"
+
+	"github.com/boltdb/bolt"
+	"github.com/groob/plist"
+	nsq "github.com/nsqio/go-nsq"
+
+	"github.com/micromdm/micromdm/event"
+)
+
+const (
+	// channel is the NSQ channel to listen on.
+	channel = "archiver"
+
+	// checkinBucket is the name of the *bolt.DB bucket
+	// to archive events in.
+	checkinBucket = "checkin"
+)
+
+func Persist(stop <-chan bool, boltDB *bolt.DB) error {
+	cfg := nsq.NewConfig()
+	db, err := newBoltStore(boltDB)
+	if err != nil {
+		return err
+	}
+	authenticate, err := nsq.NewConsumer("mdm.Authenticate", channel, cfg)
+	if err != nil {
+		return err
+	}
+	tokenUpdate, err := nsq.NewConsumer("mdm.TokenUpdate", channel, cfg)
+	if err != nil {
+		return err
+	}
+	checkout, err := nsq.NewConsumer("mdm.Checkout", channel, cfg)
+	if err != nil {
+		return err
+	}
+	errs := make(chan error)
+	go func() {
+		authenticate.AddHandler(nsq.HandlerFunc(func(m *nsq.Message) error {
+			return db.SaveEvent(m.Body)
+		}))
+
+		if err := authenticate.ConnectToNSQD("localhost:4150"); err != nil {
+			errs <- err
+		}
+	}()
+	go func() {
+		tokenUpdate.AddHandler(nsq.HandlerFunc(func(m *nsq.Message) error {
+			return db.SaveEvent(m.Body)
+		}))
+
+		if err := tokenUpdate.ConnectToNSQD("localhost:4150"); err != nil {
+			errs <- err
+		}
+	}()
+	go func() {
+		checkout.AddHandler(nsq.HandlerFunc(func(m *nsq.Message) error {
+			return db.SaveEvent(m.Body)
+		}))
+
+		if err := checkout.ConnectToNSQD("localhost:4150"); err != nil {
+			errs <- err
+		}
+	}()
+
+	for {
+		select {
+		case err := <-errs:
+			return err
+
+		case <-stop:
+			return nil
+		}
+	}
+}
+
+type store struct {
+	*bolt.DB
+}
+
+func newBoltStore(db *bolt.DB) (*store, error) {
+	err := db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucketIfNotExists([]byte(checkinBucket))
+		if err != nil {
+			return fmt.Errorf("create bucket: %s", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &store{db}, nil
+}
+
+func (db *store) SaveEvent(ev []byte) error {
+	var checkin event.CheckinEvent
+	if err := plist.Unmarshal(ev, &checkin); err != nil {
+		return err
+	}
+	err := db.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(checkinBucket))
+		if bucket == nil {
+			return fmt.Errorf("bucket %q not found!", checkinBucket)
+		}
+		k := fmt.Sprintf("%d", checkin.Time)
+		return bucket.Put([]byte(k), ev)
+	})
+	return err
+}

--- a/checkin/service.go
+++ b/checkin/service.go
@@ -1,99 +1,10 @@
 package checkin
 
-import (
-	"time"
-
-	"github.com/micromdm/mdm"
-	"github.com/micromdm/micromdm/device"
-	"github.com/micromdm/micromdm/management"
-)
+import "github.com/micromdm/mdm"
 
 // Service defines methods for and MDM Checkin service
 type Service interface {
 	Authenticate(mdm.CheckinCommand) error
 	TokenUpdate(mdm.CheckinCommand) error
 	Checkout(mdm.CheckinCommand) error
-}
-
-// NewService creates a checkin service.
-func NewService(devices device.Datastore, ms management.Service) Service {
-	return &service{
-		devices: devices,
-		mgmt:    ms,
-	}
-}
-
-type service struct {
-	devices device.Datastore
-	mgmt    management.Service
-}
-
-func (svc service) Authenticate(cmd mdm.CheckinCommand) error {
-	var udid, serialNumber device.JsonNullString
-
-	if err := udid.Scan(cmd.UDID); err != nil {
-		return err
-	}
-
-	if err := serialNumber.Scan(cmd.SerialNumber); err != nil {
-		return err
-	}
-
-	dev := &device.Device{
-		UDID:         udid,
-		SerialNumber: serialNumber,
-		OSVersion:    cmd.OSVersion,
-		BuildVersion: cmd.BuildVersion,
-		ProductName:  cmd.ProductName,
-		IMEI:         cmd.IMEI,
-		MEID:         cmd.MEID,
-		MDMTopic:     cmd.Topic,
-		Model:        cmd.Model,
-		DeviceName:   cmd.DeviceName,
-		LastCheckin:  time.Now().UTC(),
-	}
-
-	_, err := svc.devices.New("authenticate", dev)
-	return err
-}
-
-func (svc service) TokenUpdate(cmd mdm.CheckinCommand) error {
-	if cmd.UserID != "" {
-		// don't handle user updates for now
-		return nil
-	}
-	token := cmd.Token.String()
-	unlockToken := cmd.UnlockToken.String()
-	existing, err := svc.devices.GetDeviceByUDID(cmd.UDID, []string{"device_uuid"}...)
-	if err != nil {
-		return err
-	}
-	existing.Token = token
-	existing.MDMTopic = cmd.Topic
-	existing.PushMagic = cmd.PushMagic
-	existing.UnlockToken = unlockToken
-	existing.AwaitingConfiguration = cmd.AwaitingConfiguration
-	existing.Enrolled = true
-	existing.LastCheckin = time.Now().UTC()
-
-	err = svc.devices.Save("tokenUpdate", existing)
-	if err != nil {
-		return err
-	}
-	// trigger a push notification
-	svc.mgmt.Push(cmd.UDID)
-	return nil
-}
-
-func (svc service) Checkout(cmd mdm.CheckinCommand) error {
-	existing, err := svc.devices.GetDeviceByUDID(cmd.UDID, []string{"device_uuid"}...)
-	if err != nil {
-		return err
-	}
-	existing.Enrolled = false
-	err = svc.devices.Save("checkout", existing)
-	if err != nil {
-		return err
-	}
-	return nil
 }

--- a/checkin/service/direct/direct.go
+++ b/checkin/service/direct/direct.go
@@ -1,0 +1,96 @@
+// Package direct implements the checkin.Service by talking directly to a
+// datastore.
+// This implementation is deprecated.
+package direct
+
+import (
+	"time"
+
+	"github.com/micromdm/mdm"
+	"github.com/micromdm/micromdm/device"
+	"github.com/micromdm/micromdm/management"
+)
+
+// NewService creates a checkin service.
+func NewService(devices device.Datastore, ms management.Service) *Service {
+	return &Service{
+		devices: devices,
+		mgmt:    ms,
+	}
+}
+
+// Service implements the checkin service
+type Service struct {
+	devices device.Datastore
+	mgmt    management.Service
+}
+
+func (svc *Service) Authenticate(cmd mdm.CheckinCommand) error {
+	var udid, serialNumber device.JsonNullString
+
+	if err := udid.Scan(cmd.UDID); err != nil {
+		return err
+	}
+
+	if err := serialNumber.Scan(cmd.SerialNumber); err != nil {
+		return err
+	}
+
+	dev := &device.Device{
+		UDID:         udid,
+		SerialNumber: serialNumber,
+		OSVersion:    cmd.OSVersion,
+		BuildVersion: cmd.BuildVersion,
+		ProductName:  cmd.ProductName,
+		IMEI:         cmd.IMEI,
+		MEID:         cmd.MEID,
+		MDMTopic:     cmd.Topic,
+		Model:        cmd.Model,
+		DeviceName:   cmd.DeviceName,
+		LastCheckin:  time.Now().UTC(),
+	}
+
+	_, err := svc.devices.New("authenticate", dev)
+	return err
+}
+
+func (svc *Service) TokenUpdate(cmd mdm.CheckinCommand) error {
+	if cmd.UserID != "" {
+		// don't handle user updates for now
+		return nil
+	}
+	token := cmd.Token.String()
+	unlockToken := cmd.UnlockToken.String()
+	existing, err := svc.devices.GetDeviceByUDID(cmd.UDID, []string{"device_uuid"}...)
+	if err != nil {
+		return err
+	}
+	existing.Token = token
+	existing.MDMTopic = cmd.Topic
+	existing.PushMagic = cmd.PushMagic
+	existing.UnlockToken = unlockToken
+	existing.AwaitingConfiguration = cmd.AwaitingConfiguration
+	existing.Enrolled = true
+	existing.LastCheckin = time.Now().UTC()
+
+	err = svc.devices.Save("tokenUpdate", existing)
+	if err != nil {
+		return err
+	}
+	// trigger a push notification
+	svc.mgmt.Push(cmd.UDID)
+	return nil
+}
+
+func (svc *Service) Checkout(cmd mdm.CheckinCommand) error {
+	existing, err := svc.devices.GetDeviceByUDID(cmd.UDID, []string{"device_uuid"}...)
+	if err != nil {
+		return err
+	}
+	existing.Enrolled = false
+	err = svc.devices.Save("checkout", existing)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/checkin/service/event/service.go
+++ b/checkin/service/event/service.go
@@ -1,0 +1,39 @@
+// Package nsq implements the checkin.Service by writing checkin events to
+// an event publisher.
+package event
+
+import (
+	"github.com/micromdm/mdm"
+	"github.com/micromdm/micromdm/event"
+)
+
+// Service implements the checkin.Service.
+type Service struct {
+	publisher *event.Publisher
+}
+
+func NewCheckinService(publisher *event.Publisher) *Service {
+	return &Service{
+		publisher: publisher,
+	}
+}
+
+func (svc *Service) Authenticate(command mdm.CheckinCommand) error {
+	return svc.createAndPublish("mdm.Authenticate", command)
+}
+
+func (svc *Service) TokenUpdate(command mdm.CheckinCommand) error {
+	return svc.createAndPublish("mdm.TokenUpdate", command)
+}
+
+func (svc *Service) Checkout(command mdm.CheckinCommand) error {
+	return svc.createAndPublish("mdm.Checkout", command)
+}
+
+func (svc *Service) createAndPublish(topic string, command mdm.CheckinCommand) error {
+	event, err := event.CreateCheckinEvent(command)
+	if err != nil {
+		return err
+	}
+	return svc.publisher.Publish(topic, event)
+}

--- a/checkin/transport.go
+++ b/checkin/transport.go
@@ -1,8 +1,6 @@
 package checkin
 
 import (
-	"fmt"
-	"io/ioutil"
 	"net/http"
 
 	"golang.org/x/net/context"
@@ -34,13 +32,8 @@ func ServiceHandler(ctx context.Context, svc Service, logger kitlog.Logger) http
 }
 
 func decodeMDMCheckinRequest(_ context.Context, r *http.Request) (interface{}, error) {
-	data, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		return nil, err
-	}
-	fmt.Println(string(data))
 	var request mdmCheckinRequest
-	if err := plist.Unmarshal(data, &request); err != nil {
+	if err := plist.NewDecoder(r.Body).Decode(&request); err != nil {
 		return nil, err
 	}
 	return request, nil

--- a/command/service/bolt/bolt.go
+++ b/command/service/bolt/bolt.go
@@ -1,0 +1,148 @@
+package bolt
+
+import (
+	"fmt"
+
+	"github.com/boltdb/bolt"
+	"github.com/groob/plist"
+	"github.com/micromdm/mdm"
+)
+
+type Service struct {
+	*bolt.DB
+}
+
+func NewCommandService(db *bolt.DB) *Service {
+	return &Service{db}
+}
+
+const commandBucket = "commands"
+
+func (svc *Service) NewCommand(request *mdm.CommandRequest) (*mdm.Payload, error) {
+	payload, err := mdm.NewPayload(request)
+	if err != nil {
+		return nil, err
+	}
+	data, err := plist.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	// save Key, Payload
+	err = svc.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(commandBucket))
+		if bucket == nil {
+			return fmt.Errorf("bucket %q not found!", commandBucket)
+		}
+		return bucket.Put([]byte(payload.CommandUUID), data)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// queue command in device bucket
+	err = svc.Update(func(tx *bolt.Tx) error {
+		bucket, err := tx.CreateBucketIfNotExists([]byte(request.UDID))
+		if err != nil {
+			return fmt.Errorf("create device bucket: %s", err)
+		}
+		return bucket.Put([]byte(payload.CommandUUID), data)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return payload, nil
+}
+
+func (svc *Service) NextCommand(deviceUDID string) ([]byte, int, error) {
+	var (
+		next  []byte
+		total int
+	)
+	err := svc.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(deviceUDID))
+		if bucket == nil {
+			return fmt.Errorf("bucket %q not found!", []byte(deviceUDID))
+		}
+		_, next = bucket.Cursor().First()
+		total = bucket.Stats().KeyN
+		return nil
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+	return next, total, nil
+}
+
+func (svc *Service) DeleteCommand(deviceUDID string, commandUUID string) (int, error) {
+	var total int
+	// delete the command from the command bucket.
+	err := svc.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(commandBucket))
+		if bucket == nil {
+			return fmt.Errorf("bucket %q not found!", commandBucket)
+		}
+		return bucket.Delete([]byte(commandUUID))
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	// delete it from the device queue.
+	err = svc.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(deviceUDID))
+		if bucket == nil {
+			return fmt.Errorf("bucket %q not found!", deviceUDID)
+		}
+		total = bucket.Stats().KeyN - 1
+		return bucket.Delete([]byte(commandUUID))
+	})
+	if err != nil {
+		return 0, err
+	}
+	return total, nil
+}
+
+func (svc *Service) Commands(deviceUDID string) ([]mdm.Payload, error) {
+	var payloads []mdm.Payload
+	err := svc.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(deviceUDID))
+		if bucket == nil {
+			return fmt.Errorf("bucket %q not found!", deviceUDID)
+		}
+		err := bucket.ForEach(func(k, v []byte) error {
+			var payload mdm.Payload
+			if err := plist.Unmarshal(v, &payload); err != nil {
+				return err
+			}
+			payloads = append(payloads, payload)
+			return nil
+		})
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return payloads, nil
+}
+
+func (svc *Service) Find(commandUUID string) (*mdm.Payload, error) {
+	var payload mdm.Payload
+	err := svc.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(commandBucket))
+		if bucket == nil {
+			return fmt.Errorf("bucket %q not found!", commandBucket)
+		}
+		data := bucket.Get([]byte(commandUUID))
+		if data == nil {
+			return fmt.Errorf("command %q not found!", commandUUID)
+		}
+		if err := plist.Unmarshal(data, &payload); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &payload, nil
+}

--- a/event/checkin.go
+++ b/event/checkin.go
@@ -1,0 +1,33 @@
+package event
+
+import (
+	"time"
+
+	"github.com/groob/plist"
+	"github.com/micromdm/mdm"
+	nsq "github.com/nsqio/go-nsq"
+	uuid "github.com/satori/go.uuid"
+)
+
+type CheckinEvent struct {
+	ID    string
+	Time  int64
+	Event mdm.CheckinCommand
+}
+
+func CreateCheckinEvent(command mdm.CheckinCommand) ([]byte, error) {
+	event := CheckinEvent{
+		ID:    uuid.NewV4().String(),
+		Time:  time.Now().UnixNano(),
+		Event: command,
+	}
+	return plist.Marshal(&event)
+}
+
+type Publisher struct {
+	Producer *nsq.Producer
+}
+
+func (p *Publisher) Publish(topic string, event []byte) error {
+	return p.Producer.Publish(topic, event)
+}


### PR DESCRIPTION
Previously we were writing events directly to a datastore. This branch is the beginning of work to transition publishing events to a message queue instead. 

move previous checkin service to `checkin/service/direct`
add new event package for MDM events. use an NSQ producer to publish events to a topic.
add new implementation of checkin service in `checkin/service/event` The event version writes `Authenticate, TokenUpdate and Checkout` events to individual topics. 

Here's an example way to "subscribe" to an event topic with NSQ. This can be done outside the micromdm process. 

```
package main

import (
	"fmt"
	"log"
	"time"

	"github.com/nsqio/go-nsq"
)

func main() {

	cfg := nsq.NewConfig()

	c, err := nsq.NewConsumer("mdm.Authenticate", "printer", cfg)
	if err != nil {
		log.Fatal(err)
	}
	go func() {
		c.AddHandler(nsq.HandlerFunc(func(m *nsq.Message) error {
			fmt.Println(string(m.Body))
			return nil
		}))

		if err := c.ConnectToNSQD("localhost:4150"); err != nil {
			panic(err)
		}
	}()

	// Sleep a little to give everything time to start up and let
	// our producer and consumer run
	time.Sleep(5 * time.Minute)

}
```