### PR TITLE
preserve cursor during DEP fetch

### DIFF
--- a/depsync/config.go
+++ b/depsync/config.go
@@ -1,0 +1,52 @@
+package depsync
+
+import (
+	"encoding/json"
+
+	"github.com/boltdb/bolt"
+	"github.com/pkg/errors"
+)
+
+type config struct {
+	*bolt.DB
+	Cursor cursor `json:"cursor"`
+}
+
+func (cfg *config) Save() error {
+	err := cfg.Update(func(tx *bolt.Tx) error {
+		bkt, err := tx.CreateBucketIfNotExists([]byte(ConfigBucket))
+		if err != nil {
+			return err
+		}
+		v, err := json.Marshal(cfg)
+		if err != nil {
+			return err
+		}
+		return bkt.Put([]byte("configuration"), v)
+	})
+	return errors.Wrap(err, "saving dep sync cursor")
+}
+
+func LoadConfig(db *bolt.DB) (*config, error) {
+	conf := config{DB: db}
+	err := db.Update(func(tx *bolt.Tx) error {
+		bkt, err := tx.CreateBucketIfNotExists([]byte(ConfigBucket))
+		if err != nil {
+			return err
+		}
+
+		v := bkt.Get([]byte("configuration"))
+		if v == nil {
+			return nil
+		}
+		if err := json.Unmarshal(v, &conf); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &conf, nil
+}

--- a/serve.go
+++ b/serve.go
@@ -571,7 +571,7 @@ func (c *config) setupDEPSync() {
 		return
 	}
 
-	_, c.err = depsync.New(client, c.pubclient)
+	_, c.err = depsync.New(client, c.pubclient, c.db)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
For #88

load/save DEP cursor boltdb storage. Call sync once cursor is exhausted.
The sync response handling is still a TODO.