### PR TITLE
Fix panic where popFirst() can return nil

### DIFF
--- a/queue/queue.go
+++ b/queue/queue.go
@@ -76,11 +76,11 @@ func (db *Store) Next(ctx context.Context, resp mdm.Response) (*Command, error) 
 	cmd, dc.Commands = popFirst(dc.Commands)
 	if cmd != nil {
 		dc.Commands = append(dc.Commands, *cmd)
-	}
 
-	if cmd.UUID == resp.CommandUUID && resp.Status == "NotNow" {
-		// This command was just handled by NotNow, ignore.
-		cmd = nil
+		if cmd.UUID == resp.CommandUUID && resp.Status == "NotNow" {
+			// This command was just handled by NotNow, ignore.
+			cmd = nil
+		}
 	}
 
 	if err := db.Save(dc); err != nil {


### PR DESCRIPTION
We were immediately using the nil pointer afterwards.