### PR TITLE
Avoid 500 response for empty command queue

### DIFF
--- a/queue/queue.go
+++ b/queue/queue.go
@@ -27,6 +27,9 @@ type Store struct {
 func (db *Store) Next(ctx context.Context, resp mdm.Response) (*Command, error) {
 	dc, err := db.DeviceCommand(resp.UDID)
 	if err != nil {
+		if isNotFound(err) {
+			return nil, nil
+		}
 		return nil, errors.Wrapf(err, "get device command from queue, udid: %s", resp.UDID)
 	}
 

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -137,7 +137,7 @@ func TestNext_zeroCommands(t *testing.T) {
 			resp := mdm.Response{CommandUUID: s, Status: s}
 			cmd, err := store.Next(ctx, resp)
 			if err != nil {
-				t.Error("expected nil but got err")
+				t.Errorf("expected nil but got err %s", err)
 			}
 			if cmd != nil {
 				t.Errorf("expected nil cmd but got %s", cmd.UUID)

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -137,7 +137,7 @@ func TestNext_zeroCommands(t *testing.T) {
 			resp := mdm.Response{CommandUUID: s, Status: s}
 			cmd, err := store.Next(ctx, resp)
 			if err != nil {
-				t.Errorf("expected nil but got err %s", err)
+				t.Errorf("expected nil, but got err: %s", err)
 			}
 			if cmd != nil {
 				t.Errorf("expected nil cmd but got %s", cmd.UUID)

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -136,8 +136,8 @@ func TestNext_zeroCommands(t *testing.T) {
 		t.Run(s, func(t *testing.T) {
 			resp := mdm.Response{CommandUUID: s, Status: s}
 			cmd, err := store.Next(ctx, resp)
-			if err == nil {
-				t.Error("expected err but got nil")
+			if err != nil {
+				t.Error("expected nil but got err")
 			}
 			if cmd != nil {
 				t.Errorf("expected nil cmd but got %s", cmd.UUID)


### PR DESCRIPTION
Noticed that empty command queues were throwing a 500 error to clients. Catch that and handle a little more gracefully.