### PR TITLE
Use the Profile service/store for the enrollment profile.

### DIFF
--- a/enroll/service.go
+++ b/enroll/service.go
@@ -106,9 +106,11 @@ func NewService(pushTopic, caCertPath, scepURL, scepChallenge, url, tlsCertPath,
 		if err != nil {
 			return svc, err
 		}
-	}
 
-	return svc, err
+		return svc, nil
+	} else {
+		return svc, err
+	}
 }
 
 type service struct {

--- a/enroll/transport_http.go
+++ b/enroll/transport_http.go
@@ -26,7 +26,7 @@ func MakeHTTPHandlers(ctx context.Context, endpoints Endpoints, opts ...httptran
 		EnrollHandler: httptransport.NewServer(
 			endpoints.GetEnrollEndpoint,
 			decodeMDMEnrollRequest,
-			encodeResponse,
+			encodeMobileconfigResponse,
 			opts...,
 		),
 		OTAEnrollHandler: httptransport.NewServer(
@@ -95,6 +95,13 @@ func encodeResponse(ctx context.Context, w http.ResponseWriter, response interfa
 	}
 
 	return nil
+}
+
+func encodeMobileconfigResponse(ctx context.Context, w http.ResponseWriter, response interface{}) error {
+	w.Header().Set("Content-Type", "application/x-apple-aspen-config")
+	mcResp := response.(mobileconfigResponse)
+	_, err := w.Write(mcResp.Mobileconfig)
+	return err
 }
 
 func decodeOTAPhase2Phase3Request(_ context.Context, r *http.Request) (interface{}, error) {

--- a/serve.go
+++ b/serve.go
@@ -160,6 +160,9 @@ func serve(args []string) error {
 	}
 
 	sm.setupEnrollmentService()
+	if sm.err != nil {
+		stdlog.Fatalf("enrollment service: %s", sm.err)
+	}
 
 	bpDB, err := blueprint.NewDB(sm.db, sm.profileDB)
 	if err != nil {
@@ -211,7 +214,7 @@ func serve(args []string) error {
 
 	dc, err := sm.depClient()
 	if err != nil {
-		stdlog.Fatalf("creating DEP client %s\n", err)
+		stdlog.Fatalf("creating DEP client: %s\n", err)
 	}
 	tokenDB := &deptoken.DB{DB: sm.db, Publisher: sm.pubclient}
 	var listsvc list.Service

--- a/serve.go
+++ b/serve.go
@@ -216,7 +216,7 @@ func serve(args []string) error {
 	tokenDB := &deptoken.DB{DB: sm.db, Publisher: sm.pubclient}
 	var listsvc list.Service
 	{
-		l := &list.ListService{DB: sm.db, DEPClient: dc, Devices: devDB, Tokens: tokenDB, Blueprints: bpDB, Profiles: profDB}
+		l := &list.ListService{DEPClient: dc, Devices: devDB, Tokens: tokenDB, Blueprints: bpDB, Profiles: sm.profileDB}
 		listsvc = l
 
 		if err := l.WatchTokenUpdates(sm.pubclient); err != nil {
@@ -240,7 +240,7 @@ func serve(args []string) error {
 
 	var applysvc apply.Service
 	{
-		l := &apply.ApplyService{DB: sm.db, DEPClient: dc, Blueprints: bpDB, Tokens: tokenDB, Profiles: profDB}
+		l := &apply.ApplyService{DEPClient: dc, Blueprints: bpDB, Tokens: tokenDB, Profiles: sm.profileDB}
 		applysvc = l
 		if err := l.WatchTokenUpdates(sm.pubclient); err != nil {
 			stdlog.Fatal(err)
@@ -273,7 +273,7 @@ func serve(args []string) error {
 
 	listAPIHandlers := list.MakeHTTPHandlers(ctx, listEndpoints, connectOpts...)
 
-	rmsvc := &remove.RemoveService{Blueprints: bpDB, Profiles: profDB}
+	rmsvc := &remove.RemoveService{Blueprints: bpDB, Profiles: sm.profileDB}
 	removeAPIHandlers := remove.MakeHTTPHandlers(ctx, remove.MakeEndpoints(rmsvc), connectOpts...)
 
 	connectHandlers := connect.MakeHTTPHandlers(ctx, connectEndpoints, connectOpts...)


### PR DESCRIPTION
This allows the custom modification of the enrollment profile by the end user. However as a trade off we now essentially store a "static" enrollment profile. This is intended to change in the future when "templated" profiles are implemented where dynamic substring replacement (for example) is allowed in a Mobileconfig. This will allow for more dynamic-yet-custom profiles in the case of e.g. per-device SCEP challenges without having to have completely generated (and thus less flexible profiles).