### PR TITLE
use context.TODO instead of nil context

### DIFF
--- a/push/service.go
+++ b/push/service.go
@@ -39,10 +39,12 @@ func (svc *Push) startQueuedSubscriber(push *push.Service, sub pubsub.Subscriber
 				cq, err := queue.UnmarshalQueuedCommand(event.Message)
 				if err != nil {
 					fmt.Println(err)
+					continue
 				}
-				_, err = svc.Push(nil, cq.DeviceUDID)
+				_, err = svc.Push(context.TODO(), cq.DeviceUDID)
 				if err != nil {
 					fmt.Println(err)
+					continue
 				}
 			}
 		}


### PR DESCRIPTION
according to the library docs, a nil context should never be passed
context.TODO() returns an empty context value instead: https://golang.org/pkg/context/

