### PR TITLE
Fix nil panic on command request API

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -95,7 +95,7 @@
   branch = "master"
   name = "github.com/micromdm/mdm"
   packages = ["."]
-  revision = "2e3f297ba6a2e801dec12771c92c301b8e15f76c"
+  revision = "33dc653861c4691c3579fd1d26a4b5bf26302cb4"
 
 [[projects]]
   name = "github.com/micromdm/scep"

--- a/command/endpoint.go
+++ b/command/endpoint.go
@@ -26,7 +26,7 @@ func MakeNewCommandEndpoint(svc Service) endpoint.Endpoint {
 		if req.UDID == "" || req.RequestType == "" {
 			return newCommandResponse{Err: errEmptyRequest}, nil
 		}
-		payload, err := svc.NewCommand(ctx, req.CommandRequest)
+		payload, err := svc.NewCommand(ctx, &req.CommandRequest)
 		if err != nil {
 			return newCommandResponse{Err: err}, nil
 		}
@@ -66,7 +66,7 @@ func EndpointLoggingMiddleware(logger log.Logger) endpoint.Middleware {
 }
 
 type newCommandRequest struct {
-	*mdm.CommandRequest
+	mdm.CommandRequest
 }
 
 type newCommandResponse struct {

--- a/command/transport_http_test.go
+++ b/command/transport_http_test.go
@@ -1,0 +1,35 @@
+package command
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestDecodeRequest(t *testing.T) {
+	requestData := `
+{
+    "request_type": "InstallApplication",
+    "udid" : "564D38A0-4C3B-AD69-803B-DAC58A298191",
+    "manifest_url" : "https://mdm.acme.co/repo/munkitools-3.0.0.3298.plist",
+    "management_flags" : 1
+}
+`
+	req := httptest.NewRequest("POST", "https://mdm.acme.co/v1/commands", strings.NewReader(requestData))
+	request, err := decodeRequest(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded := request.(newCommandRequest)
+
+	if have, want := decoded.RequestType, "InstallApplication"; have != want {
+		t.Errorf("have %s, want %s", have, want)
+	}
+
+	if have, want := decoded.CommandRequest.InstallApplication.ManifestURL,
+		"https://mdm.acme.co/repo/munkitools-3.0.0.3298.plist"; have != want {
+		t.Errorf("have %s, want %s", have, want)
+	}
+
+}


### PR DESCRIPTION
Fixes issues introduced by 
https://github.com/micromdm/mdm/pull/15 
https://github.com/micromdm/mdm/pull/16 
and solved in
https://github.com/micromdm/mdm/pull/17

The micromdm/mdm library changed the structure of  the `mdm.CommandRequest` field, causing the decode method to panic. Fixed and added test. 
