### PR TITLE
mdmctl: support generating appmanifest

### DIFF
--- a/cmd/mdmctl/apply.go
+++ b/cmd/mdmctl/apply.go
@@ -56,6 +56,8 @@ func (cmd *applyCommand) Run(args []string) error {
 		run = cmd.applyDEPProfile
 	case "profiles":
 		run = cmd.applyProfile
+	case "app":
+		run = cmd.applyApp
 	default:
 		cmd.Usage()
 		os.Exit(1)
@@ -73,6 +75,7 @@ Valid resource types:
   * profiles
   * dep-tokens
   * dep-profiles
+  * app
 
 Examples:
   # Apply a Blueprint.

--- a/cmd/mdmctl/apply_app.go
+++ b/cmd/mdmctl/apply_app.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"io/ioutil"
+	"log"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/groob/plist"
+	"github.com/micromdm/micromdm/appmanifest"
+	"github.com/pkg/errors"
+)
+
+func (cmd *applyCommand) applyApp(args []string) error {
+	flagset := flag.NewFlagSet("app", flag.ExitOnError)
+	var (
+		flPkgPath     = flagset.String("pkg", "", "path to a distribution pkg.")
+		flPkgURL      = flagset.String("pkg-url", "", "use custom pkg url")
+		flAppManifest = flagset.String("manifest", "-", `path to an app manifest. optional,
+		will be created if file does not exist.`)
+
+		flHashSize = flagset.Int64("md5size", appmanifest.DefaultMD5Size, "md5 hash size in bytes (optional)")
+		flSign     = flagset.String("sign", "", "sign package before importing, requires specifying a product ID (optional)")
+	)
+	flagset.Usage = usageFor(flagset, "mdmctl apply app [flags]")
+	if err := flagset.Parse(args); err != nil {
+		return err
+	}
+
+	pkgurl := *flPkgURL
+	if pkgurl == "" {
+		su, err := cmd.serverRepoURL()
+		if err != nil {
+			return err
+		}
+		pkgurl = pkgURL(su, *flPkgPath)
+	}
+
+	pkg := *flPkgPath
+	signed, err := checkSignature(pkg)
+	if err != nil {
+		return err
+	}
+
+	if !signed {
+		if *flSign == "" {
+			flagset.Usage()
+			return errors.New(`MDM packages must be signed. Provide signed package or Developer ID with -sign flag`)
+		}
+		outpath := filepath.Join(os.TempDir(), filepath.Base(*flPkgPath))
+		if err := signPackage(*flPkgPath, outpath, *flSign); err != nil {
+			return err
+		}
+		pkg = outpath // use signed package to create the manifest
+	}
+
+	// open pkg file
+	f, err := os.Open(pkg)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	opts := []appmanifest.Option{appmanifest.WithMD5Size(*flHashSize)}
+	manifest, err := appmanifest.Create(&appFile{f}, pkgurl, opts...)
+	if err != nil {
+		return errors.Wrap(err, "creating manifest")
+	}
+
+	var buf bytes.Buffer
+	enc := plist.NewEncoder(&buf)
+	enc.Indent("  ")
+	if err := enc.Encode(manifest); err != nil {
+		return err
+	}
+
+	switch *flAppManifest {
+	case "":
+	case "-":
+		_, err := os.Stdout.Write(buf.Bytes())
+		return err
+	default:
+		return ioutil.WriteFile(*flAppManifest, buf.Bytes(), 0644)
+	}
+
+	return nil
+}
+
+func (cmd *applyCommand) serverRepoURL() (string, error) {
+	serverURL, err := url.Parse(cmd.config.ServerURL)
+	if err != nil {
+		return "", err
+	}
+	serverURL.Path = "/repo"
+	return serverURL.String(), nil
+}
+
+func pkgURL(repoURL, pkgPath string) string {
+	return path.Join(repoURL, filepath.Base(pkgPath))
+}
+
+// replaces .pkg with .plist
+func manifestURL(repoURL, pkgPath string) string {
+	pu := pkgURL(repoURL, pkgPath)
+	trimmed := strings.TrimSuffix(pu, path.Ext(pu))
+	return trimmed + ".plist"
+}
+
+type appFile struct {
+	*os.File
+}
+
+func (af *appFile) Size() int64 {
+	info, err := af.Stat()
+	if err != nil {
+		log.Fatal(err)
+	}
+	return info.Size()
+}

--- a/cmd/mdmctl/sign.go
+++ b/cmd/mdmctl/sign.go
@@ -1,0 +1,13 @@
+// +build !darwin
+
+package main
+
+import "fmt"
+
+func signPackage(path, outpath, developerID string) error {
+	return fmt.Errorf("package signing only implemented on macOS")
+}
+
+func checkSignature(pkgpath string) (bool, error) {
+	return false, fmt.Errorf("package signing only implemented on macOS")
+}

--- a/cmd/mdmctl/sign.go
+++ b/cmd/mdmctl/sign.go
@@ -5,9 +5,11 @@ package main
 import "fmt"
 
 func signPackage(path, outpath, developerID string) error {
-	return fmt.Errorf("package signing only implemented on macOS")
+	fmt.Println("[WARNING] package signing only implemented on macOS")
+	return nil
 }
 
 func checkSignature(pkgpath string) (bool, error) {
-	return false, fmt.Errorf("package signing only implemented on macOS")
+	fmt.Println("[WARNING] package signing only implemented on macOS. An unsigned macOS package will not install with MDM.")
+	return true, nil
 }

--- a/cmd/mdmctl/sign_darwin.go
+++ b/cmd/mdmctl/sign_darwin.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+
+	"github.com/pkg/errors"
+)
+
+func signPackage(pkgpath, outpath string, developerID string) error {
+	cmd := exec.Command("/usr/bin/productsign", "--sign", developerID, pkgpath, outpath)
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	if err := cmd.Run(); err != nil {
+		return errors.Wrap(err, "signing package")
+	}
+	return nil
+}
+
+func checkSignature(pkgpath string) (bool, error) {
+	cmd := exec.Command("pkgutil", "--check-signature", pkgpath)
+	cmd.Stderr = os.Stderr
+	out, err := cmd.Output()
+	if err != nil && !isNoSignature(out) {
+		return false, errors.Wrap(err, "checking signature")
+	}
+
+	if bytes.Contains(out, []byte(`Status: signed`)) {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func isNoSignature(out []byte) bool {
+	return bytes.Contains(out, []byte(`Status: no signature`))
+}


### PR DESCRIPTION
generate an appmanifest. validates and optionally signs packages.

For #93 

No support for uploads yet, but I'll handle that in another PR. 

The package validates signature but not if the pkg is a distribution package. This is a TODO, as I wasn't sure what the best mechanism for checking that information would be. 

Usage: 
```
USAGE
  mdmctl apply app [flags]

FLAGS
  -manifest -        path to an app manifest. optional,
                     will be created if file does not exist.
  -md5size 10485760  md5 hash size in bytes (optional)
  -pkg               path to a distribution pkg.
  -pkg-url           use custom pkg url
  -sign              sign package before importing, requires specifying a product ID (optional)
```

Example:
```
mdmctl apply app -pkg ~/Downloads/munkitools-2.8.2.2855.pkg -sign "Developer ID Installer: Victor Vrantchan (FooBarBaz)"

productsign: using timestamp authority for signature
productsign: signing product with identity "Developer ID Installer: Victor Vrantchan (FooBarBaz)" from keychain /Users/victor/Library/Keychains/login.keychain-db
productsign: adding certificate "Developer ID Certification Authority"
productsign: adding certificate "Apple Root CA"
productsign: Wrote signed product archive to /var/folders/02/k62z5c796fs5gm651jc610v80000gn/T/munkitools-2.8.2.2855.pkg
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
  <dict>
    <key>items</key>
    <array>
      <dict>
        <key>assets</key>
        <array>
          <dict>
            <key>kind</key>
            <string>software-package</string>
            <key>md5-size</key>
            <integer>3471762</integer>
            <key>md5s</key>
            <array>
              <string>08c3e7843f8b81fd44de6386619d0c39</string>
            </array>
            <key>url</key>
            <string>https:/mdm.acme.co/repo/munkitools-2.8.2.2855.pkg</string>
          </dict>
        </array>
      </dict>
    </array>
  </dict>
</plist>
```