### PR TITLE
update lockfile for latest dependencies

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -50,10 +50,10 @@
   version = "v0.4"
 
 [[projects]]
-  branch = "revert-275-go-context-stdlib"
+  branch = "master"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
-  revision = "154c03a3a9331d88d991096c1c3023aafafecf64"
+  revision = "5a0f697c9ed9d68fef0116532c6e05cfeae00e55"
 
 [[projects]]
   name = "github.com/gorilla/context"
@@ -77,7 +77,7 @@
   branch = "master"
   name = "github.com/groob/plist"
   packages = ["."]
-  revision = "43f06cf03cbc5bd95dd0ba102ac68efab25e1c65"
+  revision = "cd4f0bb6166577d40876bd169683d481e8082502"
 
 [[projects]]
   branch = "master"
@@ -89,7 +89,7 @@
   branch = "master"
   name = "github.com/micromdm/dep"
   packages = ["."]
-  revision = "f54fcb18eae9524c27a5e3f619fd2f8ee63ec57b"
+  revision = "3e565f89e59266df10c92da54118bf13ec312905"
 
 [[projects]]
   branch = "master"
@@ -119,25 +119,25 @@
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["acme","acme/autocert","pkcs12","pkcs12/internal/rc2"]
-  revision = "7e9105388ebff089b3f99f0ef676ea55a6da3a7e"
+  revision = "e1a4589e7d3ea14a3352255d04b6f1a418845e5e"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
   packages = ["context","context/ctxhttp","http2","http2/hpack","idna","lex/httplex"]
-  revision = "48359f4f600b3a2d5cf657458e3f940021631a56"
+  revision = "3da985ce5951d99de868be4385f21ea6c2b22f24"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix"]
-  revision = "a55a76086885b80f79961eacb876ebd8caf3868d"
+  revision = "b90f89a1e7a9c1f6b918820b3daa7f08488c8594"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/text"
   packages = ["internal/gen","internal/triegen","internal/ucd","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable"]
-  revision = "19e51611da83d6be54ddafce4a4af510cb3e9ea4"
+  revision = "4ee4af566555f5fbe026368b75596286a312663a"
 
 [[projects]]
   branch = "master"


### PR DESCRIPTION
main purpose is to update the plist library so recent changes to Marshalling/Unmarshalling from #183 actually work.
Also updating `micromdm/dep` to add tvOS fields.  