### PR TITLE
Fixed formatting in mdmctl for #240

### DIFF
--- a/cmd/mdmctl/get_app.go
+++ b/cmd/mdmctl/get_app.go
@@ -14,7 +14,7 @@ import (
 type appsTableOutput struct{ w *tabwriter.Writer }
 
 func (out *appsTableOutput) BasicHeader() {
-	fmt.Fprintf(out.w, "Name\t,ManifestURL\n")
+	fmt.Fprintf(out.w, "Name\tManifestURL\n")
 }
 
 func (out *appsTableOutput) BasicFooter() {


### PR DESCRIPTION
This will fix the formatting issue, but when trying to test it, I realized the help page doesn't show apps as a valid subcommand:

```
mdmctl get apps                          1 ↵  4922  07:58:34

Display one or many resources.

Valid resource types:

  * devices
  * blueprints

Examples:
  # Get a list of devices
  mdmctl get devices

  # Get a device by serial (TODO implement filtering)
  mdmctl get devices -serial=C02ABCDEF****
```

I could run mdmctl get devices and see the header, but it threw an error about connecting to the server (which is fine), but apps displayed help. Either `apps` is not registered as a subcommand of mdmctl or I'm doing it wrong ;) 