### PR TITLE
Fixed https prepend logic

### DIFF
--- a/cmd/mdmctl/config.go
+++ b/cmd/mdmctl/config.go
@@ -97,8 +97,8 @@ func setCmd(cfg *ClientConfig, args []string) error {
 	}
 
 	if *flServerURL != "" {
-		if !strings.HasPrefix(*flServerURL, "http") ||
-			!strings.HasPrefix(*flServerURL, "https") {
+		if !(strings.HasPrefix(*flServerURL, "http") ||
+			strings.HasPrefix(*flServerURL, "https")) {
 			*flServerURL = "https://" + *flServerURL
 		}
 		u, err := url.Parse(*flServerURL)


### PR DESCRIPTION
Looks like what we want now:

```
./build/darwin/mdmctl config set -api-token='secret' -server-url=http://localhost:8000
http://localhost:8000


./build/darwin/mdmctl config set -api-token='secret' -server-url=https://localhost:8000
https://localhost:8000


./build/darwin/mdmctl config set -api-token='secret' -server-url=localhost:8000
https://localhost:8000
```