### PR TITLE
Remove u.Scheme as we are handling that just before parsing

### DIFF
--- a/cmd/mdmctl/config.go
+++ b/cmd/mdmctl/config.go
@@ -96,23 +96,32 @@ func setCmd(cfg *ClientConfig, args []string) error {
 		cfg.APIToken = *flToken
 	}
 
-	if *flServerURL != "" {
-		if !(strings.HasPrefix(*flServerURL, "http") ||
-			strings.HasPrefix(*flServerURL, "https")) {
-			*flServerURL = "https://" + *flServerURL
-		}
-		u, err := url.Parse(*flServerURL)
-		if err != nil {
-			return err
-		}
-		u.Scheme = "https"
-		u.Path = "/"
-		cfg.ServerURL = u.String()
+	validatedURL, err := validateServerURL(*flServerURL)
+	if err != nil {
+		return err
 	}
+	cfg.ServerURL = validatedURL
 
 	cfg.SkipVerify = *flSkipVerify
 
 	return SaveClientConfig(cfg)
+}
+
+func validateServerURL(serverURL string) (string, error) {
+	if serverURL != "" {
+		if !(strings.HasPrefix(serverURL, "http") ||
+			strings.HasPrefix(serverURL, "https")) {
+			serverURL = "https://" + serverURL
+		}
+		u, err := url.Parse(serverURL)
+		if err != nil {
+			return "", err
+		}
+		u.Path = "/"
+		serverURL = u.String()
+	}
+	return serverURL, nil
+
 }
 
 func clientConfigPath() (string, error) {

--- a/cmd/mdmctl/config_test.go
+++ b/cmd/mdmctl/config_test.go
@@ -1,0 +1,41 @@
+package main
+
+import "testing"
+
+func TestValidateServerURL(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "http",
+			input:    "http://localhost:8000",
+			expected: "http://localhost:8000/",
+		},
+		{
+			name:     "https",
+			input:    "https://localhost:8000",
+			expected: "https://localhost:8000/",
+		},
+		{
+			name:     "trailing_slash",
+			input:    "https://localhost:8000/",
+			expected: "https://localhost:8000/",
+		},
+		{
+			name:     "no_prefix",
+			input:    "localhost:8000",
+			expected: "https://localhost:8000/",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualURL, _ := validateServerURL(tt.input)
+			if have, want := actualURL, tt.expected; have != want {
+				t.Errorf("have %s, want %s", have, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Used `mdmctl confing print` to validate insteasd of fmt.Println().

```
./build/darwin/mdmctl config set -api-token='secret' -server-url=https://localhost:8000
./build/darwin/mdmctl config print
{
  "api_token": "secret",
  "server_url": "https://localhost:8000/",
  "skip_verify": false
}

# With trailing slash is fine as well
./build/darwin/mdmctl config set -api-token='secret' -server-url=https://localhost:8000/
./build/darwin/mdmctl config print
{
  "api_token": "secret",
  "server_url": "https://localhost:8000/",
  "skip_verify": false
}

./build/darwin/mdmctl config set -api-token='secret' -server-url=http://localhost:8000
./build/darwin/mdmctl config print
{
  "api_token": "secret",
  "server_url": "http://localhost:8000/",
  "skip_verify": false
}


./build/darwin/mdmctl config set -api-token='secret' -server-url=localhost:8000
./build/darwin/mdmctl config print
{
  "api_token": "secret",
  "server_url": "https://localhost:8000/",
  "skip_verify": false
}
```