### PR TITLE
timeout boltdb open connections after 1 second

### DIFF
--- a/serve.go
+++ b/serve.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/fullsailor/pkcs7"
 	"github.com/groob/finalizer/logutil"
@@ -546,10 +547,12 @@ func (c *config) setupBolt() {
 		return
 	}
 	dbPath := filepath.Join(c.configPath, "micromdm.db")
-	c.db, c.err = bolt.Open(dbPath, 0644, nil)
-	if c.err != nil {
+	db, err := bolt.Open(dbPath, 0644, &bolt.Options{Timeout: time.Second})
+	if err != nil {
+		c.err = errors.Wrap(err, "opening boltdb")
 		return
 	}
+	c.db = db
 }
 
 func (c *config) loadPushCerts() {


### PR DESCRIPTION
Closes #267 

The default BoltDB configuration tries to establish a file lock forever and if two instances of micromdm are started, the second instance prevents the server from starting up. 