### PR TITLE
create push service from TLS cert if there's no cert in the DB

### DIFF
--- a/cmd/mdmctl/mdmcert.go
+++ b/cmd/mdmctl/mdmcert.go
@@ -225,7 +225,7 @@ func (cmd *mdmcertCommand) runUpload(args []string) error {
 }
 
 func loadPushCerts(certPath, keyPath, keyPass string) (cert, key []byte, err error) {
-	isP12 := (keyPath == "" && keyPass != "")
+	isP12 := filepath.Ext(certPath) == ".p12"
 	if isP12 {
 		pkcs12Data, err := ioutil.ReadFile(certPath)
 		if err != nil {

--- a/serve.go
+++ b/serve.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
@@ -639,6 +640,13 @@ func (c *config) setupPushService(logger log.Logger) {
 	var opts []nanopush.Option
 	{
 		cert, _ := c.configDB.PushCertificate()
+		if c.pushCert.Certificate != nil && cert == nil {
+			cert = &tls.Certificate{
+				Certificate: [][]byte{c.pushCert.Certificate.Raw},
+				PrivateKey:  c.pushCert.PrivateKey,
+				Leaf:        c.pushCert.Certificate,
+			}
+		}
 		if cert == nil {
 			goto after
 		}


### PR DESCRIPTION
fixes a few small issues related to starting a server with the deprecated -apns-cert flag. 