### PR TITLE
add usage text for dep-profiles

### DIFF
--- a/cmd/mdmctl/get_dep_profiles.go
+++ b/cmd/mdmctl/get_dep_profiles.go
@@ -20,13 +20,27 @@ func (out *depProfilesTableOutput) BasicFooter() {
 	out.w.Flush()
 }
 
+const noUUIDText = `The DEP API does not support listing profiles. 
+A UUID flag must be specified. To get currently assigned profile UUIDs run
+	mdmctl get dep-devices -serials=serial1,serial2,serial3
+The output of the dep-devices response will contain the profile UUIDs.
+`
+
 func (cmd *getCommand) getDEPProfiles(args []string) error {
 	flagset := flag.NewFlagSet("dep-profiles", flag.ExitOnError)
-	flProfilePath := flagset.String("f", "", "filename of DEP profile to apply")
-	flUUID := flagset.String("uuid", "", "DEP Profile UUID")
+	var (
+		flProfilePath = flagset.String("f", "", "filename of DEP profile to apply")
+		flUUID        = flagset.String("uuid", "", "DEP Profile UUID(required)")
+	)
 	flagset.Usage = usageFor(flagset, "mdmctl get dep-profiles [flags]")
 	if err := flagset.Parse(args); err != nil {
 		return err
+	}
+
+	if *flUUID == "" {
+		fmt.Println(noUUIDText)
+		flagset.Usage()
+		os.Exit(1)
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
Closes #288 

```
mdmctl get dep-profiles

The DEP API does not support listing profiles.
A UUID flag must be specified. To get currently assigned profile UUIDs run
	mdmctl get dep-devices -serials=serial1,serial2,serial3
The output of the dep-devices response will contain the profile UUIDs.

USAGE
  mdmctl get dep-profiles [flags]

FLAGS
  -f      filename of DEP profile to apply
  -uuid   DEP Profile UUID
```

Good short term fix, in the future it would be great to also cache known UUIDs and print them out instead. 