### PR TITLE
Fix quirky Makefile ENV vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ all: build
 
 .PHONY: build
 
+USER = $(shell whoami)
 ifndef ($(GOPATH))
 	GOPATH = $(HOME)/go
 endif
@@ -11,7 +12,6 @@ VERSION = $(shell git describe --tags --always --dirty)
 BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
 REVISION = $(shell git rev-parse HEAD)
 REVSHORT = $(shell git rev-parse --short HEAD)
-USER = $(shell whoami)
 GOVERSION = $(shell go version | awk '{print $$3}')
 NOW	= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 SHELL = /bin/bash


### PR DESCRIPTION
Fixes #313 

Because the whoami has no other dependencies, it's safe to move this up a few lines and fixes the strange quirk that `ifndef` isn't triggered while it should be.