### PR TITLE
Fix issue where errors.Wrap()-ing an error hides its interface type

### DIFF
--- a/platform/remove/builtin/db.go
+++ b/platform/remove/builtin/db.go
@@ -38,7 +38,7 @@ func (db *DB) DeviceByUDID(udid string) (*remove.Device, error) {
 		}
 		return remove.UnmarshalDevice(v, &dev)
 	})
-	return &dev, errors.Wrap(err, "remove: get device by udid")
+	return &dev, err
 }
 
 func (db *DB) Save(dev *remove.Device) error {
@@ -70,7 +70,7 @@ func (db *DB) Delete(udid string) error {
 		}
 		return b.Delete([]byte(udid))
 	})
-	return errors.Wrapf(err, "delete device with udid %s", udid)
+	return err
 }
 
 type notFound struct {

--- a/platform/remove/builtin/db.go
+++ b/platform/remove/builtin/db.go
@@ -38,7 +38,7 @@ func (db *DB) DeviceByUDID(udid string) (*remove.Device, error) {
 		}
 		return remove.UnmarshalDevice(v, &dev)
 	})
-	return &dev, err
+	return &dev, errors.Wrap(err, "remove: get device by udid")
 }
 
 func (db *DB) Save(dev *remove.Device) error {
@@ -70,7 +70,7 @@ func (db *DB) Delete(udid string) error {
 		}
 		return b.Delete([]byte(udid))
 	})
-	return err
+	return errors.Wrapf(err, "delete device with udid %s", udid)
 }
 
 type notFound struct {

--- a/platform/remove/remove.go
+++ b/platform/remove/remove.go
@@ -74,6 +74,6 @@ func isNotFound(err error) bool {
 		NotFound() bool
 	}
 
-	_, ok := err.(notFoundError)
+	_, ok := errors.Cause(err).(notFoundError)
 	return ok
 }


### PR DESCRIPTION
This was manifesting in every connect command failing for every device because no device was yet in the block (remove) database during the middleware calls. The `isNotFound()` check was failing because the returned error was not an `notFound{}`, instead the new error that errors.Wrap wrapped it in.