### PR TITLE
Raise command API limit

### DIFF
--- a/platform/command/transport_http.go
+++ b/platform/command/transport_http.go
@@ -47,7 +47,7 @@ func EncodeError(ctx context.Context, err error, w http.ResponseWriter) {
 
 func decodeRequest(ctx context.Context, r *http.Request) (interface{}, error) {
 	var req newCommandRequest
-	err := json.NewDecoder(io.LimitReader(r.Body, 10000)).Decode(&req)
+	err := json.NewDecoder(io.LimitReader(r.Body, 100000)).Decode(&req)
 	return req, err
 }
 


### PR DESCRIPTION
When you take a large-ish profile (for example), add the data encoding (base64) then wrap it in another encoding (JSON) it can get above the 10k limit. Bump up that limit.