### PR TITLE
Reject UserAuthentication attempts per MDM spec

### DIFF
--- a/mdm/checkin/endpoint.go
+++ b/mdm/checkin/endpoint.go
@@ -27,14 +27,12 @@ func MakeCheckinEndpoint(svc Service) endpoint.Endpoint {
 		case "CheckOut":
 			err = svc.CheckOut(ctx, req.CheckinCommand)
 		case "UserAuthenticate":
+			// TODO: to support per-user MDM. See #293
 			err = &rejectUserAuth{}
 		default:
 			err = errInvalidMessageType
 		}
-		if err != nil {
-			return checkinResponse{Err: err}, nil
-		}
-		return checkinResponse{}, nil
+		return checkinResponse{Err: err}, nil
 	}
 }
 
@@ -57,8 +55,6 @@ func (e *rejectUserAuth) Error() string {
 func (e *rejectUserAuth) UserAuthReject() bool {
 	return true
 }
-
-func (e *rejectUserAuth) error() error { return e }
 
 func isRejectedUserAuth(err error) bool {
 	type rejectUserAuthError interface {

--- a/mdm/checkin/endpoint.go
+++ b/mdm/checkin/endpoint.go
@@ -2,10 +2,10 @@ package checkin
 
 import (
 	"context"
-	"errors"
 
 	"github.com/go-kit/kit/endpoint"
 	"github.com/micromdm/mdm"
+	"github.com/pkg/errors"
 )
 
 // errInvalidMessageType is an invalid checking command.
@@ -26,8 +26,10 @@ func MakeCheckinEndpoint(svc Service) endpoint.Endpoint {
 			err = svc.TokenUpdate(ctx, req.CheckinCommand)
 		case "CheckOut":
 			err = svc.CheckOut(ctx, req.CheckinCommand)
+		case "UserAuthenticate":
+			err = &rejectUserAuth{}
 		default:
-			return checkinResponse{Err: errInvalidMessageType}, nil
+			err = errInvalidMessageType
 		}
 		if err != nil {
 			return checkinResponse{Err: err}, nil
@@ -45,3 +47,25 @@ type checkinResponse struct {
 }
 
 func (r checkinResponse) error() error { return r.Err }
+
+type rejectUserAuth struct{}
+
+func (e *rejectUserAuth) Error() string {
+	return "reject user auth"
+}
+
+func (e *rejectUserAuth) UserAuthReject() bool {
+	return true
+}
+
+func (e *rejectUserAuth) error() error { return e }
+
+func isRejectedUserAuth(err error) bool {
+	type rejectUserAuthError interface {
+		error
+		UserAuthReject() bool
+	}
+
+	_, ok := errors.Cause(err).(rejectUserAuthError)
+	return ok
+}

--- a/mdm/checkin/transport_http.go
+++ b/mdm/checkin/transport_http.go
@@ -53,6 +53,12 @@ func encodeResponse(ctx context.Context, w http.ResponseWriter, response interfa
 // ServerErrorEncoder to encode error responses.
 // According to the MDM Check-in protocol specification, the device only needs
 // a 401 (Unauthorized) response in case of failure.
+// In the case of a UserAuthenticate message we can also respond with 410 to
+// reject user authentication attempts
 func EncodeError(ctx context.Context, err error, w http.ResponseWriter) {
+	if isRejectedUserAuth(err) {
+		w.WriteHeader(http.StatusGone)
+		return
+	}
 	w.WriteHeader(http.StatusUnauthorized)
 }


### PR DESCRIPTION
I could have sworn we were doing this already, but I think I got confused with [commandment](https://github.com/cmdmnt/commandment/blob/9258be54b9ba9c0595768da02fa6ee8fb6054163/commandment/mdm/app.py#L155-L157) where it was implemented it. :)

In any case this will reject UserAuthentication attempts with the special 410 (Gone) HTTP status code per the MDM spec. This is for two reasons. One is when I recall in my testing that when you reject the UserAuthenticate message you don't get [the prompt for management settings](https://derflounder.wordpress.com/2013/11/13/bypassing-the-mavericks-managed-preferences-login-check/). The other is that we probably shouldn't be sending the wrong response. We appear to be sending an a 401 response for unknown Checkin request MessageTypes which I'm not sure how mdmclient handles for e.g. the UserAuthenticate.