### PR TITLE
OTA Enrollment with an enroll invite id and device id webhook

### DIFF
--- a/mdm/checkin/checkin.go
+++ b/mdm/checkin/checkin.go
@@ -47,6 +47,7 @@ func (svc *Checkin) Authenticate(ctx context.Context, cmd mdm.CheckinCommand) er
 	if cmd.MessageType != "Authenticate" {
 		return fmt.Errorf("expected Authenticate, got %s MessageType", cmd.MessageType)
 	}
+	fmt.Println(cmd)
 	return svc.archiveAndPublish(AuthenticateTopic, cmd)
 }
 
@@ -54,6 +55,7 @@ func (svc *Checkin) TokenUpdate(ctx context.Context, cmd mdm.CheckinCommand) err
 	if cmd.MessageType != "TokenUpdate" {
 		return fmt.Errorf("expected TokenUpdate, got %s MessageType", cmd.MessageType)
 	}
+	fmt.Println(cmd)
 	return svc.archiveAndPublish(TokenUpdateTopic, cmd)
 }
 
@@ -61,6 +63,7 @@ func (svc *Checkin) CheckOut(ctx context.Context, cmd mdm.CheckinCommand) error 
 	if cmd.MessageType != "CheckOut" {
 		return fmt.Errorf("expected CheckOut, but got %s MessageType", cmd.MessageType)
 	}
+	fmt.Println(cmd)
 	return svc.archiveAndPublish(CheckoutTopic, cmd)
 }
 
@@ -86,6 +89,7 @@ func (svc *Checkin) archive(nano int64, msg []byte) error {
 func (svc *Checkin) archiveAndPublish(topic string, cmd mdm.CheckinCommand) error {
 	event := NewEvent(cmd)
 	msg, err := MarshalEvent(event)
+
 	if err != nil {
 		return errors.Wrap(err, "marshal checkin event")
 	}

--- a/mdm/enroll/endpoint.go
+++ b/mdm/enroll/endpoint.go
@@ -43,6 +43,10 @@ type otaEnrollmentRequest struct {
 	UserShortName string
 }
 
+type otaInitialRequest struct{
+	challenge string
+}
+
 type mdmEnrollRequest struct{}
 
 type mobileconfigResponse struct {
@@ -81,7 +85,7 @@ func MakeGetEnrollEndpoint(s Service) endpoint.Endpoint {
 
 func MakeOTAEnrollEndpoint(s Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		mc, err := s.OTAEnroll(ctx)
+		mc, err := s.OTAEnroll(ctx, request.(otaInitialRequest).challenge)
 		return mobileconfigResponse{mc, err}, nil
 	}
 }
@@ -103,7 +107,7 @@ func MakeOTAPhase2Phase3Endpoint(s Service, scepDepot *boltdepot.Depot) endpoint
 			// signing certificate is signed by the Apple Device CA. this means
 			// we don't yet have a SCEP identity and thus are in Phase 2 of the
 			// OTA enrollment
-			mc, err := s.OTAPhase2(ctx)
+			mc, err := s.OTAPhase2(ctx, req.otaEnrollmentRequest.Challenge, req.otaEnrollmentRequest.UDID)
 			return mobileconfigResponse{mc, err}, nil
 		}
 

--- a/mdm/enroll/transport_http.go
+++ b/mdm/enroll/transport_http.go
@@ -46,8 +46,11 @@ func MakeHTTPHandlers(ctx context.Context, endpoints Endpoints, opts ...httptran
 	return h
 }
 
-func decodeEmptyRequest(_ context.Context, _ *http.Request) (interface{}, error) {
-	return nil, nil
+func decodeEmptyRequest(_ context.Context, r *http.Request) (interface{}, error) {
+	challenge := r.URL.Query().Get("challenge")
+	request := otaInitialRequest{challenge: challenge}
+
+	return request, nil
 }
 
 func decodeMDMEnrollRequest(_ context.Context, r *http.Request) (interface{}, error) {

--- a/platform/device/builtin/db.go
+++ b/platform/device/builtin/db.go
@@ -347,6 +347,10 @@ func (db *DB) pollCheckin(pubsubSvc pubsub.PublishSubscriber) error {
 					fmt.Println(err)
 					continue
 				}
+				fmt.Printf("device %s checked out\n", ev.Command.UDID)
+				if err := pubsubSvc.Publish(context.TODO(), device.DeviceDisenrolledTopic, event.Message); err != nil {
+					fmt.Println(err)
+				}
 			}
 		}
 	}()

--- a/platform/device/device.go
+++ b/platform/device/device.go
@@ -10,6 +10,8 @@ import (
 )
 
 const DeviceEnrolledTopic = "mdm.DeviceEnrolled"
+const DeviceDisenrolledTopic = "mdm.DeviceDisenrolled"
+
 
 type Device struct {
 	UUID                   string

--- a/workflow/webhook/checkin.go
+++ b/workflow/webhook/checkin.go
@@ -1,0 +1,64 @@
+package webhook
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/micromdm/micromdm/platform/pubsub"
+	"github.com/pkg/errors"
+	"github.com/micromdm/micromdm/mdm/checkin"
+	"encoding/json"
+	"bytes"
+)
+
+//const contentType = "application/x-apple-aspen-mdm"
+
+type CheckinWebhook struct {
+	Topic       string
+	EventType   string
+	CallbackURL string
+	HTTPClient  *http.Client
+}
+
+func NewCheckinWebhook(httpClient *http.Client, name string, topic, callbackURL string) (*CheckinWebhook, error) {
+	if topic == "" {
+		return nil, errors.New("webhook: topic should not be empty")
+	}
+
+	if callbackURL == "" {
+		return nil, errors.New("webhook: callbackURL should not be empty")
+	}
+
+	return &CheckinWebhook{HTTPClient: httpClient, EventType: name, Topic: topic, CallbackURL: callbackURL}, nil
+}
+
+func (cw CheckinWebhook) StartListener(sub pubsub.Subscriber) error {
+	checkinEvents, err := sub.Subscribe(context.TODO(), "webhook", cw.Topic)
+	if err != nil {
+		return errors.Wrapf(err,
+			"subscribing %s webhook to %s topic", cw.EventType, cw.Topic)
+	}
+
+	go func() {
+		for {
+			select {
+			case event := <-checkinEvents:
+				var ev checkin.Event
+				if err := checkin.UnmarshalEvent(event.Message, &ev); err != nil {
+					fmt.Println(err)
+					continue
+				}
+				messageData := map[string]string{"event": cw.EventType, "udid": ev.Command.UDID}
+				messageJson, _ := json.Marshal(messageData)
+
+				_, err := cw.HTTPClient.Post(cw.CallbackURL, "application/json", bytes.NewBuffer(messageJson))
+				if err != nil {
+					fmt.Printf("error sending checking callback: %s\n", err)
+				}
+			}
+		}
+	}()
+
+	return nil
+}

--- a/workflow/webhook/enroll.go
+++ b/workflow/webhook/enroll.go
@@ -1,0 +1,52 @@
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/micromdm/micromdm/platform/pubsub"
+	"github.com/pkg/errors"
+)
+
+type EnrollWebhook struct {
+	Topic       string
+	CallbackURL string
+	HTTPClient  *http.Client
+}
+
+func NewEnrollWebhook(httpClient *http.Client, topic, callbackURL string) (*EnrollWebhook, error) {
+	if topic == "" {
+		return nil, errors.New("webhook: topic should not be empty")
+	}
+
+	if callbackURL == "" {
+		return nil, errors.New("webhook: callbackURL should not be empty")
+	}
+
+	return &EnrollWebhook{HTTPClient: httpClient, Topic: topic, CallbackURL: callbackURL}, nil
+}
+
+func (cw EnrollWebhook) StartListener(sub pubsub.Subscriber) error {
+	enrollEvent, err := sub.Subscribe(context.TODO(), "enrollWebhook", cw.Topic)
+	if err != nil {
+		return errors.Wrapf(err,
+			"subscribing enrollWebhook to %s topic", cw.Topic)
+	}
+
+	go func() {
+		for {
+
+			select {
+			case event := <-enrollEvent:
+				_, err := cw.HTTPClient.Post(cw.CallbackURL, "application/json", bytes.NewBuffer(event.Message))
+				if err != nil {
+					fmt.Printf("error sending enroll callback: %s\n", err)
+				}
+			}
+		}
+	}()
+
+	return nil
+}


### PR DESCRIPTION
Currently, this is only a prototype implementation. This pull request is mainly to share the code, not to actually merge it. 

**Objective**
I need to start the enrollment process from an external system. The external system generates an enrollment "challenge" and needs to link it to the device id after enrollment.

**Prototype implementation**
* Read the enrollment challenge from URL parameter (/ota/enroll?challenge=12345). 
* Use the supplied challenge for the first profile given to the device
* The device then returns both the challenge and device id as a part of the enrollment request.
* The device id and invite id is then sent via a webhook to the external service as a json:
```
{"challenge":"1234","event":"ota_phase1","udid":"7c31b3a19a0aa12dxxxxxxxxxxx7531e1c1fd7e"}
``` 

* Web hook triggered after enrollment has completed:
```
{"event":"enroll","udid":""7c31b3a19a0aa12dxxxxxxxxxxx7531e1c1fd7e"}
```

* After checkout:
```
* {"event":"checkout","udid":""7c31b3a19a0aa12dxxxxxxxxxxx7531e1c1fd7e"}
```


This code example might be relevant for the discussions in #320