### PR TITLE
Use externally set as parameter in checkin URL and send JSON webhook callback

### DIFF
--- a/mdm/checkin/checkin_test.go
+++ b/mdm/checkin/checkin_test.go
@@ -140,7 +140,7 @@ func TestService_Authenticate(t *testing.T) {
 			mock.PublishFn = tt.publisher
 			mock.Invoked = false
 			svc.archiveFn = tt.archiveFn
-			err := svc.Authenticate(context.Background(), tt.request)
+			err := svc.Authenticate(context.Background(), tt.request, "")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("%q. Authenticate error = %v, wantErr %v",
 					tt.name, err, tt.wantErr)
@@ -208,7 +208,7 @@ func TestService_TokenUpdate(t *testing.T) {
 			mock.PublishFn = tt.publisher
 			mock.Invoked = false
 			svc.archiveFn = tt.archiveFn
-			err := svc.TokenUpdate(context.Background(), tt.request)
+			err := svc.TokenUpdate(context.Background(), tt.request, "")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("%q. TokenUpdate error = %v, wantErr %v",
 					tt.name, err, tt.wantErr)
@@ -276,7 +276,7 @@ func TestService_CheckOut(t *testing.T) {
 			mock.PublishFn = tt.publisher
 			mock.Invoked = false
 			svc.archiveFn = tt.archiveFn
-			err := svc.CheckOut(context.Background(), tt.request)
+			err := svc.CheckOut(context.Background(), tt.request, "")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("%q. CheckOut error = %v, wantErr %v",
 					tt.name, err, tt.wantErr)

--- a/mdm/checkin/endpoint.go
+++ b/mdm/checkin/endpoint.go
@@ -21,11 +21,11 @@ func MakeCheckinEndpoint(svc Service) endpoint.Endpoint {
 		var err error
 		switch req.MessageType {
 		case "Authenticate":
-			err = svc.Authenticate(ctx, req.CheckinCommand)
+			err = svc.Authenticate(ctx, req.CheckinCommand, req.id)
 		case "TokenUpdate":
-			err = svc.TokenUpdate(ctx, req.CheckinCommand)
+			err = svc.TokenUpdate(ctx, req.CheckinCommand, req.id)
 		case "CheckOut":
-			err = svc.CheckOut(ctx, req.CheckinCommand)
+			err = svc.CheckOut(ctx, req.CheckinCommand, req.id)
 		default:
 			return checkinResponse{Err: errInvalidMessageType}, nil
 		}
@@ -38,6 +38,7 @@ func MakeCheckinEndpoint(svc Service) endpoint.Endpoint {
 
 type checkinRequest struct {
 	mdm.CheckinCommand
+	id string
 }
 
 type checkinResponse struct {

--- a/mdm/checkin/service.go
+++ b/mdm/checkin/service.go
@@ -7,7 +7,7 @@ import (
 
 // Service defines methods for and MDM Check-in service.
 type Service interface {
-	Authenticate(ctx context.Context, cmd mdm.CheckinCommand) error
-	TokenUpdate(ctx context.Context, cmd mdm.CheckinCommand) error
-	CheckOut(ctx context.Context, cmd mdm.CheckinCommand) error
+	Authenticate(ctx context.Context, cmd mdm.CheckinCommand, id string) error
+	TokenUpdate(ctx context.Context, cmd mdm.CheckinCommand, id string) error
+	CheckOut(ctx context.Context, cmd mdm.CheckinCommand, id string) error
 }

--- a/mdm/checkin/transport_http.go
+++ b/mdm/checkin/transport_http.go
@@ -32,6 +32,8 @@ type errorer interface {
 
 func decodeRequest(ctx context.Context, r *http.Request) (interface{}, error) {
 	var req checkinRequest
+	req.id = r.URL.Query().Get("id")
+
 	err := plist.NewDecoder(io.LimitReader(r.Body, 10000)).Decode(&req)
 	return req, err
 }

--- a/mdm/enroll/endpoint.go
+++ b/mdm/enroll/endpoint.go
@@ -43,7 +43,9 @@ type otaEnrollmentRequest struct {
 	UserShortName string
 }
 
-type mdmEnrollRequest struct{}
+type mdmEnrollRequest struct{
+	id	string
+}
 
 type mobileconfigResponse struct {
 	profile.Mobileconfig
@@ -67,11 +69,11 @@ func MakeGetEnrollEndpoint(s Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		switch req := request.(type) {
 		case mdmEnrollRequest:
-			mc, err := s.Enroll(ctx)
+			mc, err := s.Enroll(ctx, req.id)
 			return mobileconfigResponse{mc, err}, nil
 		case depEnrollmentRequest:
 			fmt.Printf("got DEP enrollment request from %s\n", req.Serial)
-			mc, err := s.Enroll(ctx)
+			mc, err := s.Enroll(ctx, "")
 			return mobileconfigResponse{mc, err}, nil
 		default:
 			return nil, errors.New("unknown enrollment type")
@@ -129,7 +131,7 @@ func MakeOTAPhase2Phase3Endpoint(s Service, scepDepot *boltdepot.Depot) endpoint
 			// TODO: the SCEP CA checking ought to be more robust
 			// see: https://github.com/micromdm/scep/issues/32
 
-			mc, err := s.Enroll(ctx)
+			mc, err := s.Enroll(ctx, "")
 			// profile, err := s.OTAPhase3(ctx)
 			return mobileconfigResponse{mc, err}, nil
 		}

--- a/mdm/enroll/profile_test.go
+++ b/mdm/enroll/profile_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestEnrollProfile(t *testing.T) {
 	svc := new(service)
-	profile, err := svc.MakeEnrollmentProfile()
+	profile, err := svc.MakeEnrollmentProfile("")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -31,5 +31,30 @@ func TestEnrollProfile(t *testing.T) {
 
 	if have, want := hasPerUserConnections, true; have != want {
 		t.Errorf("missing ServerCapabilities: macOS enrollment profile requires %s", perUserConnections)
+	}
+
+	if have, want := payloadContent.CheckInURL, "/mdm/checkin"; have != want {
+		t.Errorf("have checkin URL %s, want %s", have, want)
+	}
+}
+
+func TestEnrollProfileWithId(t *testing.T) {
+	id := "03c6b007-abba-46a8-8811-a639dbcfca81"
+
+	svc := new(service)
+	profile, err := svc.MakeEnrollmentProfile(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var payloadContent MDMPayloadContent
+	for _, payload := range profile.PayloadContent {
+		if c, ok := payload.(MDMPayloadContent); ok {
+			payloadContent = c
+		}
+	}
+
+	if have, want := payloadContent.CheckInURL, "/mdm/checkin?id="+id; have != want {
+		t.Errorf("have checkin URL %s, want %s", have, want)
 	}
 }

--- a/mdm/enroll/transport_http.go
+++ b/mdm/enroll/transport_http.go
@@ -53,7 +53,8 @@ func decodeEmptyRequest(_ context.Context, _ *http.Request) (interface{}, error)
 func decodeMDMEnrollRequest(_ context.Context, r *http.Request) (interface{}, error) {
 	switch r.Method {
 	case "GET":
-		return mdmEnrollRequest{}, nil
+		id := r.URL.Query().Get("id")
+		return mdmEnrollRequest{id: id}, nil
 	case "POST": // DEP request
 		data, err := ioutil.ReadAll(r.Body)
 		if err != nil {

--- a/workflow/webhook/json.go
+++ b/workflow/webhook/json.go
@@ -1,0 +1,53 @@
+package webhook
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/micromdm/micromdm/platform/pubsub"
+	"github.com/pkg/errors"
+	"bytes"
+)
+
+//const contentType = "application/x-apple-aspen-mdm"
+
+type JSONWebhook struct {
+	Topic       string
+	CallbackURL string
+	HTTPClient  *http.Client
+}
+
+func NewJSONWebhook(httpClient *http.Client, topic, callbackURL string) (*JSONWebhook, error) {
+	if topic == "" {
+		return nil, errors.New("webhook: topic should not be empty")
+	}
+
+	if callbackURL == "" {
+		return nil, errors.New("webhook: callbackURL should not be empty")
+	}
+
+	return &JSONWebhook{HTTPClient: httpClient, Topic: topic, CallbackURL: callbackURL}, nil
+}
+
+func (cw JSONWebhook) StartListener(sub pubsub.Subscriber) error {
+	events, err := sub.Subscribe(context.TODO(), "webhook", cw.Topic)
+	if err != nil {
+		return errors.Wrapf(err,
+			"subscribing JSON webhook to %s topic", cw.Topic)
+	}
+
+	go func() {
+		for {
+			select {
+			case event := <-events:
+				_, err := cw.HTTPClient.Post(cw.CallbackURL, "application/json", bytes.NewBuffer(event.Message))
+				if err != nil {
+					fmt.Printf("error sending checking callback: %s\n", err)
+				}
+			}
+		}
+	}()
+
+	return nil
+}


### PR DESCRIPTION
If an id parameter is specified in the enroll URL /mdm/enroll?id=1234, then
use this in the checkin url /mdm/checkin?id=1234 in the enrollment profile.

If checkin webhook is specified, the id and device id (UDID) will be encoded
as JSON and sent when the device check in and out.

The JSON webhook is generic and can be used for other purposes than checkin
events.