### PR TITLE
Guard aginst tls=false and supplying cert&key

### DIFF
--- a/cmd/micromdm/serve.go
+++ b/cmd/micromdm/serve.go
@@ -121,6 +121,9 @@ func serve(args []string) error {
 	if !strings.HasPrefix(*flServerURL, "https://") {
 		return errors.New("-server-url must begin with https://")
 	}
+	if *flTLS == false && (*flTLSCert != "" || *flTLSKey != "") {
+		return errors.New("cannot set -tls=false and supply -tls-cert or -tls-key")
+	}
 
 	logger := log.NewLogfmtLogger(os.Stderr)
 	stdlog.SetOutput(log.NewStdlibAdapter(logger)) // force structured logs


### PR DESCRIPTION
#268 talks about a situation where it's not clear that supplying a certificate and key will magically turn on `-tls=true`. Thus, forbid starting micromdm using those options together).