### PR TITLE
Do not allow `mdmctl config set` without args

### DIFF
--- a/cmd/mdmctl/config.go
+++ b/cmd/mdmctl/config.go
@@ -256,6 +256,9 @@ func switchServerConfig(name string) error {
 	if err != nil {
 		return err
 	}
+	if _, ok := clientCfg.Servers[name]; !ok {
+		return fmt.Errorf("No server named \"%s\" found", name)
+	}
 	clientCfg.Active = name
 	return saveClientConfig(clientCfg)
 }

--- a/cmd/mdmctl/config.go
+++ b/cmd/mdmctl/config.go
@@ -145,11 +145,10 @@ func setCmd(args []string) error {
 
 	cfg := new(ServerConfig)
 
-	validatedToken, err := validateAPIToken(*flToken)
-	if err != nil {
-		return err
+	if *flToken == "" {
+		return errors.New("bad input: api-token must be provided.")
 	}
-	cfg.APIToken = validatedToken
+	cfg.APIToken = *flToken
 
 	validatedURL, err := validateServerURL(*flServerURL)
 	if err != nil {
@@ -205,14 +204,6 @@ func validateServerURL(serverURL string) (string, error) {
 	serverURL = u.String()
 
 	return serverURL, nil
-}
-
-func validateAPIToken(apiToken string) (string, error) {
-	if apiToken == "" {
-		return apiToken, errors.New("bad input: api-token must be provided.")
-	}
-
-	return apiToken, nil
 }
 
 func clientConfigPath() (string, error) {
@@ -274,7 +265,7 @@ func switchServerConfig(name string) error {
 		return err
 	}
 	if _, ok := clientCfg.Servers[name]; !ok {
-		return fmt.Errorf("No server named \"%s\" found", name)
+		return fmt.Errorf("no server named \"%s\" found", name)
 	}
 	clientCfg.Active = name
 	return saveClientConfig(clientCfg)


### PR DESCRIPTION
Fixes issue in https://github.com/micromdm/micromdm/issues/371

I made the `-server-url` and `-api-token` flags required parameters. Additionally if set is called with no arguments at all the help is printed.

I also added a fix to make sure the switch command only allows you to switch to a server config that exists 