### PR TITLE
Prevent multiple device records with the same UDID

### DIFF
--- a/platform/device/builtin/db.go
+++ b/platform/device/builtin/db.go
@@ -218,7 +218,7 @@ func (db *DB) pollCheckin(pubsubSvc pubsub.PublishSubscriber) error {
 					fmt.Println(err) // some other issue is going on
 					continue
 				}
-				_, err = db.DeviceByUDID(ev.Command.UDID)
+				byUDID, err := db.DeviceByUDID(ev.Command.UDID)
 				if err != nil && isNotFound(err) { // never checked in
 					fmt.Printf("checking in new device %s\n", ev.Command.SerialNumber)
 				} else if err != nil {
@@ -226,6 +226,7 @@ func (db *DB) pollCheckin(pubsubSvc pubsub.PublishSubscriber) error {
 					continue
 				} else if err == nil {
 					fmt.Printf("re-enrolling device %s\n", ev.Command.SerialNumber)
+					newDevice = byUDID
 					newDevice.Enrolled = false
 				}
 


### PR DESCRIPTION
The error I was seeing was if I changed the serial number in a VM and then re-enrolled the server would create a second record for the same UDID. I recreated this condition using the ngrok set ups and then saving an example of a `checkin` request. I think changed the serial number and replayed and each time I changed and replayed I got a new device record.

Looking at the device db it looks like we weren't using the device we looked up in the `DeviceByUDID` call.

After apply this patch and retrying my testing above I instead see the serial number updated on the existing record vs a new record with the same udid.

This might be related to https://github.com/micromdm/micromdm/issues/402 but that case is slightly different. That was the udid changing but the serial number staying the same and push not working properly.