### PR TITLE
Fix code-never-reached situation

### DIFF
--- a/platform/user/worker.go
+++ b/platform/user/worker.go
@@ -81,8 +81,8 @@ func (w *Worker) updateUserFromTokenUpdate(ctx context.Context, message []byte) 
 				ev.Command.UDID,
 				ev.Command.UserID,
 			)
-			usr.UUID = uuid.NewV4().String()
 		}
+		usr.UUID = uuid.NewV4().String()
 	}
 
 	usr.UDID = ev.Command.UDID


### PR DESCRIPTION
UUID was missing on Checkin for user and erroring out in bolt for lacking a key. Probably just a simple typo in the worker refactors.