### PR TITLE
Update base container to Alpine 3.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-FROM alpine:3.6
+FROM alpine:3.7
 
 RUN apk --update add ca-certificates
-	
 
 COPY ./build/linux/micromdm /usr/bin
 


### PR DESCRIPTION
It was 3.6, but now it's 3.7! Also removed some superfluous whitespace.