### PR TITLE
Remove superfluous whitespace from markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 ### User Profiles
 
 * Added support for modifying the default enrollment profile.
-* Added support for user level profiles. 
+* Added support for user level profiles.
 * Added support for AccountConfiguration during DEP Enrollment. Specified in blueprints
 * Addes support for multiple server configs in `mdmctl`.
 * Added `mdmctl mdmcert upload` command which uploads/replaces the servers push certificate.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,14 @@
 # Contributing
 
-Welcome! If you're looking to help, this document is a great place to start! 
+Welcome! If you're looking to help, this document is a great place to start!
 
 
 ## Finding things that need help
 
 Here's a few places to get started and find out what's outstanding.
 
-- Read through the [MDM Protocol Reference](https://developer.apple.com/library/content/documentation/Miscellaneous/Reference/MobileDeviceManagementProtocolRef/3-MDM_Protocol/MDM_Protocol.html) on the Apple website. Having a deeper understanding of MDM can help with designing features and uncovering bugs. 
-- Follow the [Quickstart](https://github.com/micromdm/micromdm/wiki/Quickstart) guide and make edits if something doesn't look or work right. 
+- Read through the [MDM Protocol Reference](https://developer.apple.com/library/content/documentation/Miscellaneous/Reference/MobileDeviceManagementProtocolRef/3-MDM_Protocol/MDM_Protocol.html) on the Apple website. Having a deeper understanding of MDM can help with designing features and uncovering bugs.
+- Follow the [Quickstart](https://github.com/micromdm/micromdm/wiki/Quickstart) guide and make edits if something doesn't look or work right.
 - If you run into a problem that you're not sure how to fix, file a bug in [the issue tracker](https://github.com/micromdm/micromdm/issues)
 - Browse through the open issues in [the issue tracker](https://github.com/micromdm/micromdm/issues). We try to tag issues as [**beginner friendly**](https://github.com/micromdm/micromdm/issues?q=is%3Aissue+is%3Aopen+label%3Abeginner-friendly) where appropriate.
 - See something that others might benefit from? Considering updating or writing a [wiki page](https://github.com/micromdm/micromdm/wiki).
@@ -41,10 +41,10 @@ Example:
 git clone git@github.com:micromdm/micromdm $GOPATH/src/github.com/micromdm/micromdm
 
 # add your remote/upstream
-git remote add groob git@github.com:groob/micromdm.git 
+git remote add groob git@github.com:groob/micromdm.git
 
 # update from origin/master
-git pull --rebase 
+git pull --rebase
 
 # create a branch
 git checkout -b my_feature
@@ -69,9 +69,9 @@ A few helpful resources for getting started with Go:
 * [How to write Go code](https://golang.org/doc/code.html)
 * [GOPATH on the go wiki](https://github.com/golang/go/wiki/GOPATH)
 
-To build MicroMDM you will need to:  
+To build MicroMDM you will need to:
 
-1. Download and install [`Go`](https://golang.org/dl/)  
+1. Download and install [`Go`](https://golang.org/dl/)
 2. Make a workspace directory and set the `GOPATH` as explained above.
 3. Install [`dep`](https://github.com/golang/dep) via the command `go get -u github.com/golang/dep/...`
 Note that `dep` is a very new project itself. If you're running trouble with the `dep ensure` command, ping @groob in the #micromdm channel on Slack.
@@ -84,11 +84,11 @@ The repo must always be in the folder `$GOPATH/src/github.com/micromdm/micromdm`
 
 ## Important libraries and frameworks
 
-MicroMDM is built using a few popular Go packages outside the standard libraries. It might be worth checking them out. 
+MicroMDM is built using a few popular Go packages outside the standard libraries. It might be worth checking them out.
 
-- [Go Kit](https://github.com/go-kit/kit#go-kit------) is a set of Go libraries used by MicroMDM to provide [logging](https://github.com/go-kit/kit/tree/master/log), and abstractions for building HTTP services. Its [examples](https://gokit.io/examples/) page is a good place to start.  
+- [Go Kit](https://github.com/go-kit/kit#go-kit------) is a set of Go libraries used by MicroMDM to provide [logging](https://github.com/go-kit/kit/tree/master/log), and abstractions for building HTTP services. Its [examples](https://gokit.io/examples/) page is a good place to start.
 - [BoltDB](https://github.com/boltdb/bolt#getting-started) is a key/value database used to provide persistant storage for many components of MicroMDM.
-- [gorilla/mux](http://www.gorillatoolkit.org/pkg/mux) is used to provide routing for http handlers. 
+- [gorilla/mux](http://www.gorillatoolkit.org/pkg/mux) is used to provide routing for http handlers.
 
 ## Other resources
 

--- a/README.md
+++ b/README.md
@@ -4,21 +4,21 @@
 
 MicroMDM is a Mobile Device Management server for Apple Devices currently focused on managing macOS.
 
-## Introduction 
+## Introduction
 
-MDM is a large problem domain, and we are looking at how to solve many problems with device management and obstacles with existing solutions. However, at this stage of development we're focusing on a very specific use case which is current to many Mac Administrators: 
+MDM is a large problem domain, and we are looking at how to solve many problems with device management and obstacles with existing solutions. However, at this stage of development we're focusing on a very specific use case which is current to many Mac Administrators:
 
-> When a device enrolls (through DEP or otherwise) we want to bootstrap some tools to manage the Mac. These are agents running on a mac like Munki or Chef/Puppet which will manage the software and configuration through the lifecycle of the Mac. 
+> When a device enrolls (through DEP or otherwise) we want to bootstrap some tools to manage the Mac. These are agents running on a mac like Munki or Chef/Puppet which will manage the software and configuration through the lifecycle of the Mac.
 
 MicroMDM is able to solve this common use-case today, and we're focusing on improving the user experience for administrators and developing related features.
 
 MicroMDM is being actively developed but is **ready for you to start testing**.
 
-To get started, see the [Quickstart](https://github.com/micromdm/micromdm/wiki/Quickstart) tutorial on the wiki. 
+To get started, see the [Quickstart](https://github.com/micromdm/micromdm/wiki/Quickstart) tutorial on the wiki.
 
 ## Installing
 
-Unless you're a developer, you probably want a binary you can run. [Download](https://github.com/micromdm/micromdm/releases/latest) the latest release, either for macOS (darwin) or linux. 
+Unless you're a developer, you probably want a binary you can run. [Download](https://github.com/micromdm/micromdm/releases/latest) the latest release, either for macOS (darwin) or linux.
 
 ## Getting Help
 
@@ -26,24 +26,24 @@ The best place to get help is the `#micromdm` channel on the MacAdmins Slack tea
 
 ## Helping out
 
-Over the last year this project has gained a lot of interest from the community. We want to make it clear that at this point MicroMDM is a passion project, and is being developed by a [few fellow Mac Admins](https://github.com/micromdm/micromdm/graphs/contributors) on weekends and during conference hackathons. 
+Over the last year this project has gained a lot of interest from the community. We want to make it clear that at this point MicroMDM is a passion project, and is being developed by a [few fellow Mac Admins](https://github.com/micromdm/micromdm/graphs/contributors) on weekends and during conference hackathons.
 
-It would be great to get a few more developers to contribute, but at this point, there are _more_ important tasks than knowing how to code. Here is how you can help: 
+It would be great to get a few more developers to contribute, but at this point, there are _more_ important tasks than knowing how to code. Here is how you can help:
 
 - Read the documentation, install the tool and test MicroMDM.
-- File bugs: https://github.com/micromdm/micromdm/issues  
-- Participate in discussions. The `#micromdm` slack channel is best, but `#mdm` and `#dep` are a few relevant ones.   
+- File bugs: https://github.com/micromdm/micromdm/issues
+- Participate in discussions. The `#micromdm` slack channel is best, but `#mdm` and `#dep` are a few relevant ones.
 - Edit the [project Wiki](https://github.com/micromdm/micromdm/wiki). The wiki page is open to anyone and you can make a lot of impact on the project by submitting additional documentation or designing proposals.
 - Were you able to set up MicroMDM and enroll a few devices? Blogging about your experience. It can help others get started, or can help us figure out what we need to do better.
 
-See the [CONTRIBUTING](CONTRIBUTING.md) page for additional info. 
+See the [CONTRIBUTING](CONTRIBUTING.md) page for additional info.
 
 ## Design Goals
 
-As mentioned in the introduction, a primary use case is bootstraping Macs. That's the short term (from now until WWDC). 
+As mentioned in the introduction, a primary use case is bootstraping Macs. That's the short term (from now until WWDC).
 But there's a larger design goal we have in mind — what will differentiate MicroMDM from other vendor projects. Here it is in brief:
 
-> MicroMDM aims to provide a declarative approach to device management. Too often vendor tools expect you to manage devices by filling out various forms in a web interface. While MicroMDM might have a web interface of it's own one day, the tool itself is inspired by popular DevOps processes like Configuration Management (chef/puppet/ansible, terraform) and orchestration frameworks (Kubernetes, Docker). 
+> MicroMDM aims to provide a declarative approach to device management. Too often vendor tools expect you to manage devices by filling out various forms in a web interface. While MicroMDM might have a web interface of it's own one day, the tool itself is inspired by popular DevOps processes like Configuration Management (chef/puppet/ansible, terraform) and orchestration frameworks (Kubernetes, Docker).
 
 For example here is a process of applying a DEP profile (not to be confused with an Apple Configuration Profile, of course):
 
@@ -67,7 +67,7 @@ $ mdmctl get dep-profiles -f - -uuid=4B05B09E8AC7E7FC12C8F3338E099310
     "TOS"
   ]
 }
-``` 
+```
 
 - Expose an API for developers and administrators. Today you can send MDM commands to the server using a RESTful API. We intend to make more processes scriptable.
 - Provide a way for administrators to subscribe to events generated from the MDM interactions between client & server. MicroMDM works through a pubsub system at its core. For example, when a new device enrolls with the MDM server it doesn't record this in the database immediately, but instead creates an event which is sent on the message bus to other services that are listening. Today, this message bus is built in-memory, but we plan to expose the same hooks over the network, allowing developers to consume events in any language — not just Go.

--- a/tools/api/README.md
+++ b/tools/api/README.md
@@ -6,7 +6,7 @@ A sample of the common API requests are available as `curl` scripts. To use them
   `brew install jq`
 
 ## Setup
-Create an `env` file and define environment variables you will need to talk to the server. 
+Create an `env` file and define environment variables you will need to talk to the server.
 This env file will be sourced by the scripts.
 
 Contents of `env` file:
@@ -50,5 +50,5 @@ The `api` folder groups all MDM commands in the `commands` folder. Use these for
 ```
 
 All the scripts in this folder are tiny. Consider reading them to get an understanding of the API.
-Also consider learning `jq`. 
+Also consider learning `jq`.
 MicroMDM returns and accepts JSON for all of the API endpoints, and `jq` is a powerful tool for reading and manipulating JSON data.

--- a/tools/ngrok/README.md
+++ b/tools/ngrok/README.md
@@ -1,10 +1,10 @@
 # Local Development with ngrok
 
 When developing and testing MicroMDM you will likely want to enroll devices. Normally that means either generating or getting new TLS certificates and hosting micromdm on some publicly accessible server.
-`ngrok` is a tool that makes it easy to expose the MicroMDM server as a public URL that your devices can enroll to. 
+`ngrok` is a tool that makes it easy to expose the MicroMDM server as a public URL that your devices can enroll to.
 
-The scripts in this will help you get MicroMDM running for local development. 
-First, install the listed requirements. 
+The scripts in this will help you get MicroMDM running for local development.
+First, install the listed requirements.
 
 Next, make sure you've cloned the `micromdm` repo exactly as described in the [contributing guide](../../CONTRIBUTING.md). Follow the steps in the same document to downloads required dependencies and build `micromdm` and `mdmctl`.
 


### PR DESCRIPTION
I was just browsing around the docs and my editor trimmed out trailing whitespace.