### PR TITLE
Use micromdm/scep master (for newer pkcs7 lib)

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,10 +18,14 @@
   version = "v1.3.1"
 
 [[projects]]
-  branch = "master"
+  branch = "sha256"
   name = "github.com/fullsailor/pkcs7"
-  packages = ["."]
-  revision = "ae226422660e5ca10db350d33f81c6608f3fbcdd"
+  packages = [
+    ".",
+    "internal/x509util"
+  ]
+  revision = "f41fa115eb76823dcfb8c45678da0fb6d7ecb792"
+  source = "github.com/groob/pkcs7"
 
 [[projects]]
   branch = "master"
@@ -115,16 +119,18 @@
   revision = "deded5397014104c618443dde9408a94c8232e21"
 
 [[projects]]
+  branch = "master"
   name = "github.com/micromdm/scep"
   packages = [
+    "challenge",
+    "crypto/x509util",
+    "csrverifier",
     "depot",
     "depot/bolt",
     "scep",
-    "scep/internal/pkcs7",
     "server"
   ]
-  revision = "a202afd5e358b857c95d048fc47432759db0d9bd"
-  version = "v1.0.0"
+  revision = "528937a33139b55852ba3d2b8944dce7b3261404"
 
 [[projects]]
   name = "github.com/pkg/errors"
@@ -148,7 +154,7 @@
     "pkcs12",
     "pkcs12/internal/rc2"
   ]
-  revision = "8ac0e0d97ce45cd83d1d7243c060cb8461dda5e9"
+  revision = "fd5f17ee729917fcb39f16421460212d917a0813"
 
 [[projects]]
   branch = "master"
@@ -160,13 +166,13 @@
     "http2/hpack",
     "idna"
   ]
-  revision = "1e491301e022f8f977054da4c2d852decd59571f"
+  revision = "db08ff08e8622530d9ed3a0e8ac279f6d4c02196"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix"]
-  revision = "7c1e4f34a39c8bf93b6a3379e4ffb3b118ecc614"
+  revision = "8883426083c04a2627e6e59d84d5f6fb63d16c91"
 
 [[projects]]
   name = "golang.org/x/text"
@@ -192,6 +198,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c7f6428978cff90d51244bf8f2d30bd551e1d5f98f875187594c4d356ea2cbd5"
+  inputs-digest = "151e504814f497d3591f423ebe5be4fca6dd047d33a35ba2f66bf6fad2a72bba"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -2,7 +2,7 @@
   name = "github.com/boltdb/bolt"
   version = "v1.3.0"
 
-[[constraint]]
+[[override]]
   name = "github.com/go-kit/kit"
   version = "v0.7.0"
 
@@ -25,3 +25,12 @@
 [[constraint]]
   name = "github.com/golang/protobuf"
   version = "1.1.0"
+
+[[override]]
+  name = "github.com/micromdm/scep"
+  branch = "master"
+
+[[constraint]]
+  branch = "sha256"
+  name = "github.com/fullsailor/pkcs7"
+  source = "github.com/groob/pkcs7"

--- a/cmd/micromdm/serve.go
+++ b/cmd/micromdm/serve.go
@@ -221,7 +221,11 @@ func serve(args []string) error {
 	dc := sm.depClient
 	appDB := &appsbuiltin.Repo{Path: *flRepoPath}
 
-	scepHandler := scep.ServiceHandler(ctx, sm.scepService, httpLogger)
+	scepEndpoints := scep.MakeServerEndpoints(sm.scepService)
+	// TODO: these were taken from cmd/scepserver/scepserver.go, do we need them?
+	// e.GetEndpoint = scepserver.EndpointLoggingMiddleware(lginfo)(e.GetEndpoint)
+	// e.PostEndpoint = scepserver.EndpointLoggingMiddleware(lginfo)(e.PostEndpoint)
+	scepHandler := scep.MakeHTTPHandler(scepEndpoints, sm.scepService, log.With(logger, "component", "scep"))
 	enrollHandlers := enroll.MakeHTTPHandlers(ctx, enroll.MakeServerEndpoints(sm.enrollService, sm.scepDepot), httptransport.ServerErrorLogger(httpLogger))
 
 	r, options := httputil2.NewRouter(logger)

--- a/cmd/micromdm/serve.go
+++ b/cmd/micromdm/serve.go
@@ -222,10 +222,11 @@ func serve(args []string) error {
 	appDB := &appsbuiltin.Repo{Path: *flRepoPath}
 
 	scepEndpoints := scep.MakeServerEndpoints(sm.scepService)
-	// TODO: these were taken from cmd/scepserver/scepserver.go, do we need them?
-	// e.GetEndpoint = scepserver.EndpointLoggingMiddleware(lginfo)(e.GetEndpoint)
-	// e.PostEndpoint = scepserver.EndpointLoggingMiddleware(lginfo)(e.PostEndpoint)
-	scepHandler := scep.MakeHTTPHandler(scepEndpoints, sm.scepService, log.With(logger, "component", "scep"))
+	scepComponentLogger := log.With(logger, "component", "scep")
+	scepEndpoints.GetEndpoint = scep.EndpointLoggingMiddleware(scepComponentLogger)(scepEndpoints.GetEndpoint)
+	scepEndpoints.PostEndpoint = scep.EndpointLoggingMiddleware(scepComponentLogger)(scepEndpoints.PostEndpoint)
+	scepHandler := scep.MakeHTTPHandler(scepEndpoints, sm.scepService, scepComponentLogger)
+
 	enrollHandlers := enroll.MakeHTTPHandlers(ctx, enroll.MakeServerEndpoints(sm.enrollService, sm.scepDepot), httptransport.ServerErrorLogger(httpLogger))
 
 	r, options := httputil2.NewRouter(logger)


### PR DESCRIPTION
micromdm/scep#87 is still open for that project. But this PR should resolve #436 (as we're compiling against the fixed version of pkcs7 in @groob's branch). I've tested with a 10.12.6 VM and it seems to enroll fine, but could definitely use some testing.

I'm not super sure about the Handler changes. I feel there's a better way to do this, especially with the doubled-up path Handlers in both the scepserver MakeHandlers, and the r.Handler in micromdm. Also - the `dep` tool stuff is a bit of a nightmare, if folks can test to make sure they're `dep ensure` works fine that'd be great, too.

Feedback welcome!