### PR TITLE
Allow removal of device records

### DIFF
--- a/cmd/mdmctl/remove.go
+++ b/cmd/mdmctl/remove.go
@@ -42,6 +42,8 @@ func (cmd *removeCommand) Run(args []string) error {
 	switch strings.ToLower(args[0]) {
 	case "blueprints":
 		run = cmd.removeBlueprints
+	case "devices":
+		run = cmd.removeDevices
 	case "profiles":
 		run = cmd.removeProfiles
 	case "block":
@@ -63,6 +65,7 @@ Display one or many resources.
 Valid resource types:
 
   * blueprints
+  * devices
   * profiles
   * block
   * dep-autoassigner

--- a/cmd/mdmctl/remove_devices.go
+++ b/cmd/mdmctl/remove_devices.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+func (cmd *removeCommand) removeDevices(args []string) error {
+	flagset := flag.NewFlagSet("remove-devices", flag.ExitOnError)
+	var (
+		flIdentifier = flagset.String("udid", "", "device UDID, optionally comma separated")
+	)
+	flagset.Usage = usageFor(flagset, "mdmctl remove devices [flags]")
+	if err := flagset.Parse(args); err != nil {
+		return err
+	}
+
+	if *flIdentifier == "" {
+		return errors.New("bad input: device UDID must be provided")
+	}
+
+	ctx := context.Background()
+	err := cmd.devicesvc.RemoveDevices(ctx, strings.Split(*flIdentifier, ","))
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("removed devices(s): %s\n", *flIdentifier)
+
+	return nil
+}

--- a/platform/device/builtin/db_test.go
+++ b/platform/device/builtin/db_test.go
@@ -64,6 +64,29 @@ func TestSave(t *testing.T) {
 
 }
 
+func TestDelete(t *testing.T) {
+	db := setupDB(t)
+	dev := &device.Device{
+		UUID:         "a-b-c-d",
+		UDID:         "UDID-FOO-BAR-BAZ",
+		SerialNumber: "foobarbaz",
+		ProductName:  "MacBook",
+	}
+
+	if err := db.Save(dev); err != nil {
+		t.Fatalf("saving device in datastore: %s", err)
+	}
+
+	if err := db.Delete(dev.UDID); err != nil {
+		t.Fatalf("deleting device in datastore: %s", err)
+	}
+
+	byUDID, _ := db.DeviceByUDID(dev.UDID)
+	if byUDID != nil {
+		t.Fatalf("expected device to be deleted")
+	}
+}
+
 func setupDB(t *testing.T) *DB {
 	f, _ := ioutil.TempFile("", "bolt-")
 	f.Close()

--- a/platform/device/client.go
+++ b/platform/device/client.go
@@ -27,8 +27,20 @@ func NewHTTPClient(instance, token string, logger log.Logger, opts ...httptransp
 		).Endpoint()
 	}
 
+	var removeDevicesEndpoint endpoint.Endpoint
+	{
+		removeDevicesEndpoint = httptransport.NewClient(
+			"DELETE",
+			httputil.CopyURL(u, "/v1/devices"),
+			httputil.EncodeRequestWithToken(token, httptransport.EncodeJSONRequest),
+			decodeRemoveDevicesResponse,
+			opts...,
+		).Endpoint()
+	}
+
 	return Endpoints{
-		ListDevicesEndpoint: listDevicesEndpoint,
+		ListDevicesEndpoint:   listDevicesEndpoint,
+		RemoveDevicesEndpoint: removeDevicesEndpoint,
 	}, nil
 
 }

--- a/platform/device/remove_devices.go
+++ b/platform/device/remove_devices.go
@@ -1,0 +1,61 @@
+package device
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/go-kit/kit/endpoint"
+	"github.com/micromdm/micromdm/pkg/httputil"
+)
+
+func (svc *DeviceService) RemoveDevices(ctx context.Context, udids []string) error {
+	for _, udid := range udids {
+		err := svc.store.Delete(udid)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type removeDevicesRequest struct {
+	Identifiers []string `json:"udids"`
+}
+
+type removeDevicesResponse struct {
+	Err error `json:"err,omitempty"`
+}
+
+func (r removeDevicesResponse) Failed() error { return r.Err }
+
+func decodeRemoveDevicesRequest(ctx context.Context, r *http.Request) (interface{}, error) {
+	var req removeDevicesRequest
+	err := httputil.DecodeJSONRequest(r, &req)
+	return req, err
+}
+
+func decodeRemoveDevicesResponse(_ context.Context, r *http.Response) (interface{}, error) {
+	var resp removeDevicesResponse
+	err := httputil.DecodeJSONResponse(r, &resp)
+	return resp, err
+}
+
+func MakeRemoveDevicesEndpoint(svc Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (response interface{}, err error) {
+		req := request.(removeDevicesRequest)
+		err = svc.RemoveDevices(ctx, req.Identifiers)
+		return removeDevicesResponse{
+			Err: err,
+		}, nil
+	}
+}
+
+func (e Endpoints) RemoveDevices(ctx context.Context, ids []string) error {
+	request := removeDevicesRequest{Identifiers: ids}
+	resp, err := e.RemoveDevicesEndpoint(ctx, request)
+	if err != nil {
+		return err
+	}
+	return resp.(removeDevicesResponse).Err
+}

--- a/platform/device/server.go
+++ b/platform/device/server.go
@@ -9,21 +9,31 @@ import (
 )
 
 type Endpoints struct {
-	ListDevicesEndpoint endpoint.Endpoint
+	ListDevicesEndpoint   endpoint.Endpoint
+	RemoveDevicesEndpoint endpoint.Endpoint
 }
 
 func MakeServerEndpoints(s Service, outer endpoint.Middleware, others ...endpoint.Middleware) Endpoints {
 	return Endpoints{
-		ListDevicesEndpoint: endpoint.Chain(outer, others...)(MakeListDevicesEndpoint(s)),
+		ListDevicesEndpoint:   endpoint.Chain(outer, others...)(MakeListDevicesEndpoint(s)),
+		RemoveDevicesEndpoint: endpoint.Chain(outer, others...)(MakeRemoveDevicesEndpoint(s)),
 	}
 }
 
 func RegisterHTTPHandlers(r *mux.Router, e Endpoints, options ...httptransport.ServerOption) {
 	// GET     /v1/devices		get a list of devices managed by the server
+	// DELETE  /v1/devices		remove one or more devices from the server
 
 	r.Methods("GET").Path("/v1/devices").Handler(httptransport.NewServer(
 		e.ListDevicesEndpoint,
 		decodeListDevicesRequest,
+		httputil.EncodeJSONResponse,
+		options...,
+	))
+
+	r.Methods("DELETE").Path("/v1/devices").Handler(httptransport.NewServer(
+		e.RemoveDevicesEndpoint,
+		decodeRemoveDevicesRequest,
 		httputil.EncodeJSONResponse,
 		options...,
 	))

--- a/platform/device/service.go
+++ b/platform/device/service.go
@@ -6,10 +6,12 @@ import (
 
 type Service interface {
 	ListDevices(ctx context.Context, opt ListDevicesOption) ([]DeviceDTO, error)
+	RemoveDevices(ctx context.Context, udids []string) error
 }
 
 type Store interface {
 	List(opt ListDevicesOption) ([]Device, error)
+	Delete(udid string) error
 }
 
 type DeviceService struct {


### PR DESCRIPTION
This adds a `remove devices` command to `mdmctl`. You can pass a single UDID or a comma separated list of UDIDs. Only the device records are removed.

Resolves #394 