### PR TITLE
DeviceInformation command API example support query strings

### DIFF
--- a/tools/api/commands/device_information
+++ b/tools/api/commands/device_information
@@ -4,7 +4,9 @@ endpoint="v1/commands"
 jq -n \
   --arg request_type "DeviceInformation" \
   --arg udid "$1" \
-  '.udid = $udid 
+   --arg query_strings "$2" \
+ '.udid = $udid 
   |.request_type = $request_type
+  |.queries = ($query_strings | split(","))
   '|\
   curl $CURL_OPTS -u "micromdm:$API_TOKEN" "$SERVER_URL/$endpoint" -d@-


### PR DESCRIPTION
Adds support for specifying query strings with tools/api/commands/device_information example.

Invoking:
`./tools/api/commands/device_information 9824c12e8cb0feed3cfae91e8ec9b37dc5e019fe "OSVersion,Model,ModelName,BatteryLevel"`

Gets you:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	<key>CommandUUID</key>
	<string>195e7036-1bbc-4e20-a428-1799c10327f2</string>
	<key>QueryResponses</key>
	<dict>
		<key>BatteryLevel</key>
		<real>0.86000001430511475</real>
		<key>Model</key>
		<string>MF519LL</string>
		<key>ModelName</key>
		<string>iPad</string>
		<key>OSVersion</key>
		<string>10.3.3</string>
	</dict>
	<key>Status</key>
	<string>Acknowledged</string>
	<key>UDID</key>
	<string>9824c12e8cb0feed3cfae91e8ec9b37dc5e019fe</string>
</dict>
</plist>
```