### PR TITLE
tools/api/commands: output base64 encoded data on one line

### DIFF
--- a/tools/api/commands/install_profile
+++ b/tools/api/commands/install_profile
@@ -4,7 +4,7 @@ endpoint="v1/commands"
 jq -n \
   --arg request_type "InstallProfile" \
   --arg udid "$1" \
-  --arg payload $(cat $2|base64) \
+  --arg payload $(cat $2|openssl base64 -A) \
   '.udid = $udid
   |.payload = $payload 
   |.request_type = $request_type

--- a/tools/api/commands/install_provisioning_profile
+++ b/tools/api/commands/install_provisioning_profile
@@ -4,7 +4,7 @@ endpoint="v1/commands"
 jq -n \
   --arg request_type "InstallProvisioningProfile" \
   --arg udid "$1" \
-  --arg provisioning_profile $(cat $2|base64) \
+  --arg provisioning_profile $(cat $2|openssl base64 -A) \
   '.udid = $udid
   |.provisioning_profile = $provisioning_profile
   |.request_type = $request_type


### PR DESCRIPTION
On linux, the base64 command by default wraps the encoded output after 76 characters. This breaks the install_profile command in tools/api/commands (and presumably also the install_provisioning_profile command):
```
$ ./install_profile <udid> <profile> 
jq: error: <base64 encoded line> is not defined at <top-level>, line 1:
<base64 encoded line>
jq: 1 compile error
{
  "error": "EOF"
}
```
This can be fixed by appending the '-w0' flag to the 'base64' command in install_profile, which outputs the base64 encoded data on one line, but this flag won't be recognised on macos (the equivalent on macos is '-b0', which is the default).

One way to fix this, is to replace the 'base64' command by 'openssl base64 -A', which has the advantage that it works on both linux and macos. This PR does that replacement, for both install_profile and install_provisioning_profile.