### PR TITLE
Sync dep devices tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 vendor/
 build/
 *.zip
+*.DS_Store
 
 cmd/mdmctl/mdmdctl
 cmd/micromdm/micromdm

--- a/tools/api/sync_dep_devices
+++ b/tools/api/sync_dep_devices
@@ -1,0 +1,4 @@
+#!/bin/bash
+source $MICROMDM_ENV_PATH
+endpoint="v1/dep/syncnow"
+curl $CURL_OPTS -u "micromdm:$API_TOKEN" -X POST "$SERVER_URL/$endpoint"


### PR DESCRIPTION
This adds `sync_dep_devices` in the api tools.

Also I saw that .DS_Store files are not in the .gitignore, so I added that as well.