### PR TITLE
Support an empty body

### DIFF
--- a/platform/device/get_devices.go
+++ b/platform/device/get_devices.go
@@ -49,7 +49,11 @@ func (r getDevicesResponse) Failed() error { return r.Err }
 
 func decodeListDevicesRequest(ctx context.Context, r *http.Request) (interface{}, error) {
 	var opts ListDevicesOption
-	err := httputil.DecodeJSONRequest(r, &opts)
+	var err error
+	// support an empty GET request without a body
+	if r.ContentLength > 0 {
+		err = httputil.DecodeJSONRequest(r, &opts)
+	}
 	req := getDevicesRequest{
 		Opts: opts,
 	}


### PR DESCRIPTION
Support an empty body (i.e. don't require JSON) if the content-length is 0 for the device list.