### PR TITLE
Remove SCEP CA certificate from enrollment profile & disk

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -60,11 +60,6 @@ type Server struct {
 	CommandWebhookURL   string
 	DEPClient           dep.Client
 
-	// TODO: refactor enroll service and remove the need to reference
-	// this on-disk cert. but it might be useful to keep the PEM
-	// around for anyone who will need to export the CA.
-	SCEPCACertPath string
-
 	PushService     *push.Service // bufford push
 	APNSPushService apns.Service
 	CommandService  command.Service
@@ -335,7 +330,6 @@ func (c *Server) setupEnrollmentService() error {
 	c.EnrollService, err = enroll.NewService(
 		topicProvider,
 		c.PubClient,
-		c.SCEPCACertPath,
 		c.ServerPublicURL+"/scep",
 		c.SCEPChallenge,
 		c.ServerPublicURL,
@@ -432,14 +426,7 @@ func (c *Server) setupSCEP(logger log.Logger) error {
 		return err
 	}
 
-	caCert, err := depot.CreateOrLoadCA(key, 5, "MicroMDM", "US")
-	if err != nil {
-		return err
-	}
-
-	c.SCEPCACertPath = filepath.Join(c.ConfigPath, "SCEPCACert.pem")
-
-	err = crypto.WritePEMCertificateFile(caCert, c.SCEPCACertPath)
+	_, err = depot.CreateOrLoadCA(key, 5, "MicroMDM", "US")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The SCEP CA certificate is not needed to establish trust between the client and MDM server. Thus including it in the enrollment profile is unnecessary. Separately, and since we don't need it, we can clean up the enrollment service a little by not reading the certificate from disk. Finally — just don't write it out to disk at all. Its usefulness on disk (for the sake of being in its own file) is debatable. Does anybody use it? Besides, anybody needing it can just query `/scep?operation=GetCACert` to retrieve it.

This should probably get wide testing across various device types — MicroMDM has always included this certificate in the enrollment profile. This change worked to enroll a macOS 10.12.6 host.