### PR TITLE
Correct SCEP profile payload

### DIFF
--- a/mdm/enroll/profile.go
+++ b/mdm/enroll/profile.go
@@ -59,8 +59,8 @@ type SCEPPayloadContent struct {
 	CAFingerprint []byte `plist:"CAFingerprint,omitempty"` // NSData
 	Challenge     string `plist:"Challenge,omitempty"`
 	Keysize       int
-	KeyType       string `plist:"Key Type"`
-	KeyUsage      int    `plist:"Key Usage"`
+	KeyType       string `plist:"KeyType"`
+	KeyUsage      int    `plist:"KeyUsage"`
 	Name          string
 	Subject       [][][]string `plist:"Subject,omitempty"`
 	URL           string


### PR DESCRIPTION
Both KeyType and KeyUsage were being defined with spaces in the name.
According to the spec this is incorrect. The clients were most likely just
ignoring these fields and everything still worked but it makes sense to correct
the profile.