### PR TITLE
Remove go build -i

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,11 +70,11 @@ install-local: \
 	$(eval APP_NAME = mdmctl)
 
 mdmctl: .pre-build .pre-mdmctl
-	go build -i -o build/$(CURRENT_PLATFORM)/mdmctl -ldflags ${BUILD_VERSION} ./cmd/mdmctl
+	go build -o build/$(CURRENT_PLATFORM)/mdmctl -ldflags ${BUILD_VERSION} ./cmd/mdmctl
 
 xp-mdmctl: .pre-build .pre-mdmctl
-	GOOS=darwin go build -i -o build/darwin/mdmctl -ldflags ${BUILD_VERSION} ./cmd/mdmctl
-	GOOS=linux CGO_ENABLED=0 go build -i -o build/linux/mdmctl  -ldflags ${BUILD_VERSION} ./cmd/mdmctl
+	GOOS=darwin go build -o build/darwin/mdmctl -ldflags ${BUILD_VERSION} ./cmd/mdmctl
+	GOOS=linux CGO_ENABLED=0 go build -o build/linux/mdmctl  -ldflags ${BUILD_VERSION} ./cmd/mdmctl
 
 install-mdmctl: .pre-mdmctl
 	go install -ldflags ${BUILD_VERSION} ./cmd/mdmctl
@@ -85,14 +85,14 @@ APP_NAME = micromdm
 	$(eval APP_NAME = micromdm)
 
 micromdm: .pre-build .pre-micromdm
-	go build -i -o build/$(CURRENT_PLATFORM)/micromdm -ldflags ${BUILD_VERSION} ./cmd/micromdm
+	go build -o build/$(CURRENT_PLATFORM)/micromdm -ldflags ${BUILD_VERSION} ./cmd/micromdm
 
 install-micromdm: .pre-micromdm
 	go install -ldflags ${BUILD_VERSION} ./cmd/micromdm
 
 xp-micromdm: .pre-build .pre-micromdm
-	GOOS=darwin go build -i -o build/darwin/micromdm -ldflags ${BUILD_VERSION} ./cmd/micromdm
-	GOOS=linux CGO_ENABLED=0 go build -i -o build/linux/micromdm  -ldflags ${BUILD_VERSION} ./cmd/micromdm
+	GOOS=darwin go build -o build/darwin/micromdm -ldflags ${BUILD_VERSION} ./cmd/micromdm
+	GOOS=linux CGO_ENABLED=0 go build -o build/linux/micromdm  -ldflags ${BUILD_VERSION} ./cmd/micromdm
 
 release-zip: xp-micromdm xp-mdmctl
 	zip -r micromdm_${VERSION}.zip build/


### PR DESCRIPTION
regression per https://github.com/golang/go/issues/27285 which states we don't need `-i` anymore? literally have done zero looking into if this the right thing. just fixed builds for me.