### PR TITLE
Retrieve certificate

### DIFF
--- a/platform/config/builtin/db.go
+++ b/platform/config/builtin/db.go
@@ -77,6 +77,17 @@ func (db *DB) serverConfig() (*config.ServerConfig, error) {
 	return &conf, errors.Wrap(err, "get server config from bolt")
 }
 
+func (db *DB) GetPushCertificate() ([]byte, error) {
+	cert, err := db.PushCertificate()
+	if err != nil {
+		return nil, err
+	}
+	if len(cert.Certificate) > 0 {
+		return cert.Certificate[0], nil
+	}
+	return nil, nil
+}
+
 func (db *DB) PushCertificate() (*tls.Certificate, error) {
 	conf, err := db.serverConfig()
 	if err != nil {

--- a/platform/config/get_push_certificate.go
+++ b/platform/config/get_push_certificate.go
@@ -1,0 +1,51 @@
+package config
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/go-kit/kit/endpoint"
+	"github.com/micromdm/micromdm/pkg/httputil"
+	"github.com/pkg/errors"
+)
+
+func (svc *ConfigService) GetPushCertificate(ctx context.Context) ([]byte, error) {
+	cert, err := svc.store.GetPushCertificate()
+	if err != nil {
+		return cert, errors.Wrap(err, "get push certificate")
+	}
+	return cert, nil
+}
+
+type getResponse struct {
+	Cert []byte `json:"cert"`
+	Err  error  `json:"err,omitempty"`
+}
+
+func (r getResponse) Failed() error { return r.Err }
+
+func decodeGetPushCertificateRequest(ctx context.Context, r *http.Request) (interface{}, error) {
+	return nil, nil
+}
+
+func decodeGetPushCertificateResponse(_ context.Context, r *http.Response) (interface{}, error) {
+	var resp getResponse
+	err := httputil.DecodeJSONResponse(r, &resp)
+	return resp, err
+}
+
+func MakeGetPushCertificateEndpoint(svc Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (response interface{}, err error) {
+		cert, err := svc.GetPushCertificate(ctx)
+		return getResponse{Err: err, Cert: cert}, nil
+	}
+}
+
+func (e Endpoints) GetPushCertificate(ctx context.Context) ([]byte, error) {
+	response, err := e.GetPushCertificateEndpoint(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return response.(getResponse).Cert, response.(getResponse).Err
+}

--- a/platform/config/server.go
+++ b/platform/config/server.go
@@ -8,27 +8,37 @@ import (
 )
 
 type Endpoints struct {
-	ApplyDEPTokensEndpoint      endpoint.Endpoint
 	SavePushCertificateEndpoint endpoint.Endpoint
+	GetPushCertificateEndpoint  endpoint.Endpoint
+	ApplyDEPTokensEndpoint      endpoint.Endpoint
 	GetDEPTokensEndpoint        endpoint.Endpoint
 }
 
 func MakeServerEndpoints(s Service, outer endpoint.Middleware, others ...endpoint.Middleware) Endpoints {
 	return Endpoints{
-		ApplyDEPTokensEndpoint:      endpoint.Chain(outer, others...)(MakeApplyDEPTokensEndpoint(s)),
 		SavePushCertificateEndpoint: endpoint.Chain(outer, others...)(MakeSavePushCertificateEndpoint(s)),
+		GetPushCertificateEndpoint:  endpoint.Chain(outer, others...)(MakeGetPushCertificateEndpoint(s)),
+		ApplyDEPTokensEndpoint:      endpoint.Chain(outer, others...)(MakeApplyDEPTokensEndpoint(s)),
 		GetDEPTokensEndpoint:        endpoint.Chain(outer, others...)(MakeGetDEPTokensEndpoint(s)),
 	}
 }
 
 func RegisterHTTPHandlers(r *mux.Router, e Endpoints, options ...httptransport.ServerOption) {
 	// PUT     /v1/config/certificate		create or replace the MDM Push Certificate
+	// GET     /v1/config/certificate		retrieve the MDM Push Certificate
 	// PUT     /v1/dep-tokens				create or replace a DEP OAuth token
 	// GET     /v1/dep-tokens				get the OAuth Token used for the DEP client
 
 	r.Methods("PUT").Path("/v1/config/certificate").Handler(httptransport.NewServer(
 		e.SavePushCertificateEndpoint,
 		decodeSavePushCertificateRequest,
+		httputil.EncodeJSONResponse,
+		options...,
+	))
+
+	r.Methods("GET").Path("/v1/config/certificate").Handler(httptransport.NewServer(
+		e.GetPushCertificateEndpoint,
+		decodeGetPushCertificateRequest,
 		httputil.EncodeJSONResponse,
 		options...,
 	))

--- a/platform/config/service.go
+++ b/platform/config/service.go
@@ -9,12 +9,14 @@ import (
 
 type Service interface {
 	SavePushCertificate(ctx context.Context, cert, key []byte) error
+	GetPushCertificate(ctx context.Context) ([]byte, error)
 	ApplyDEPToken(ctx context.Context, P7MContent []byte) error
 	GetDEPTokens(ctx context.Context) ([]DEPToken, []byte, error)
 }
 
 type Store interface {
 	SavePushCertificate(cert, key []byte) error
+	GetPushCertificate() ([]byte, error)
 	PushCertificate() (*tls.Certificate, error)
 	PushTopic() (string, error)
 	DEPKeypair() (key *rsa.PrivateKey, cert *x509.Certificate, err error)


### PR DESCRIPTION
Allow reading the MDM push cert from the server. To e.g. periodically check its expiration or to idempotently update the push cert.