### PR TITLE
GET to POST for v1/blueprints endpoint

### DIFF
--- a/platform/blueprint/client.go
+++ b/platform/blueprint/client.go
@@ -29,7 +29,7 @@ func NewHTTPClient(instance, token string, logger log.Logger, opts ...httptransp
 	var getBlueprintsEndpoint endpoint.Endpoint
 	{
 		getBlueprintsEndpoint = httptransport.NewClient(
-			"GET",
+			"POST",
 			httputil.CopyURL(u, "/v1/blueprints"),
 			httputil.EncodeRequestWithToken(token, httptransport.EncodeJSONRequest),
 			decodeGetBlueprintsResponse,

--- a/platform/blueprint/server.go
+++ b/platform/blueprint/server.go
@@ -23,7 +23,7 @@ func MakeServerEndpoints(s Service, outer endpoint.Middleware, others ...endpoin
 
 func RegisterHTTPHandlers(r *mux.Router, e Endpoints, options ...httptransport.ServerOption) {
 	// PUT     /v1/blueprints			create or replace a blueprint on the server
-	// GET     /v1/blueprints			get a list of blueprints managed by the server
+	// POST    /v1/blueprints			get a list of blueprints managed by the server
 	// DELETE  /v1/blueprints			remove one or more blueprints from the server
 
 	r.Methods("PUT").Path("/v1/blueprints").Handler(httptransport.NewServer(
@@ -33,7 +33,7 @@ func RegisterHTTPHandlers(r *mux.Router, e Endpoints, options ...httptransport.S
 		options...,
 	))
 
-	r.Methods("GET").Path("/v1/blueprints").Handler(httptransport.NewServer(
+	r.Methods("POST").Path("/v1/blueprints").Handler(httptransport.NewServer(
 		e.GetBlueprintsEndpoint,
 		decodeGetBlueprintsRequest,
 		httputil.EncodeJSONResponse,


### PR DESCRIPTION
Changed GET to POST as a GET with a request body is not preferred.