### PR TITLE
GET to POST and POST to PUT for v1/apps endpoint

### DIFF
--- a/platform/appstore/client.go
+++ b/platform/appstore/client.go
@@ -19,7 +19,7 @@ func NewHTTPClient(instance, token string, logger log.Logger, opts ...httptransp
 	var appUploadEndpoint endpoint.Endpoint
 	{
 		appUploadEndpoint = httptransport.NewClient(
-			"POST",
+			"PUT",
 			httputil.CopyURL(u, "/v1/apps"),
 			httputil.EncodeRequestWithToken(token, encodeUploadAppRequest),
 			decodeUploadAppResponse,
@@ -30,7 +30,7 @@ func NewHTTPClient(instance, token string, logger log.Logger, opts ...httptransp
 	var listAppsEndpoint endpoint.Endpoint
 	{
 		listAppsEndpoint = httptransport.NewClient(
-			"GET",
+			"POST",
 			httputil.CopyURL(u, "/v1/apps"),
 			httputil.EncodeRequestWithToken(token, httptransport.EncodeJSONRequest),
 			decodeListAppsResponse,

--- a/platform/appstore/server.go
+++ b/platform/appstore/server.go
@@ -21,17 +21,17 @@ func MakeServerEndpoints(s Service, outer endpoint.Middleware, others ...endpoin
 }
 
 func RegisterHTTPHandlers(r *mux.Router, e Endpoints, options ...httptransport.ServerOption) {
-	// POST    /v1/apps			upload an app to the server
-	// GET     /v1/apps			list apps managed by the server
+	// PUT		/v1/apps			upload an app to the server
+	// POST   /v1/apps			list apps managed by the server
 
-	r.Methods("POST").Path("/v1/apps").Handler(httptransport.NewServer(
+	r.Methods("PUT").Path("/v1/apps").Handler(httptransport.NewServer(
 		e.AppUploadEndpoint,
 		decodeAppUploadRequest,
 		httputil.EncodeJSONResponse,
 		options...,
 	))
 
-	r.Methods("GET").Path("/v1/apps").Handler(httptransport.NewServer(
+	r.Methods("POST").Path("/v1/apps").Handler(httptransport.NewServer(
 		e.ListAppsEndpoint,
 		decodeListAppsRequest,
 		httputil.EncodeJSONResponse,


### PR DESCRIPTION
Changed GET to POST for "get apps" as a GET with a request body is not preferred.
Changed POST to PUT for "upload apps" as POST is now used for "get apps".