### PR TITLE
Updating to allow spaces in environment variable

### DIFF
--- a/tools/api/commands/install_profile
+++ b/tools/api/commands/install_profile
@@ -4,7 +4,7 @@ endpoint="v1/commands"
 jq -n \
   --arg request_type "InstallProfile" \
   --arg udid "$1" \
-  --arg payload "$(cat $2|openssl base64 -A)" \
+  --arg payload "$(cat "$2"|openssl base64 -A)" \
   '.udid = $udid
   |.payload = $payload 
   |.request_type = $request_type

--- a/tools/api/commands/install_provisioning_profile
+++ b/tools/api/commands/install_provisioning_profile
@@ -4,7 +4,7 @@ endpoint="v1/commands"
 jq -n \
   --arg request_type "InstallProvisioningProfile" \
   --arg udid "$1" \
-  --arg provisioning_profile "$(cat $2|openssl base64 -A)" \
+  --arg provisioning_profile "$(cat "$2"|openssl base64 -A)" \
   '.udid = $udid
   |.provisioning_profile = $provisioning_profile
   |.request_type = $request_type


### PR DESCRIPTION
When running the `api/commands/install_profile $udid "/Library/Managed Installs/profile.mobileconfig"` command (or anything with a space in the environment variable), the command returns:
`cat: /Library/Managed: No such file or directory`
`cat: Installs/profile.mobileconfig: No such file or directory`

Added quotes around the variable to fix.