### PR TITLE
set acknowledge time when moving command to completed queue

### DIFF
--- a/platform/queue/queue.go
+++ b/platform/queue/queue.go
@@ -4,6 +4,7 @@ package queue
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/boltdb/bolt"
 	"github.com/go-kit/kit/log"
@@ -75,6 +76,7 @@ func (db *Store) nextCommand(ctx context.Context, resp mdm.Response) (*Command, 
 	case "Acknowledged":
 		// move to completed, send next
 		x, a := cut(dc.Commands, resp.CommandUUID)
+		x.Acknowledged = time.Now()
 		dc.Commands = a
 		if x == nil {
 			break
@@ -99,6 +101,7 @@ func (db *Store) nextCommand(ctx context.Context, resp mdm.Response) (*Command, 
 		dc.Failed = append(dc.Failed, *x)
 
 	case "Idle":
+
 		// will send next command below
 
 	default:

--- a/platform/queue/queue.go
+++ b/platform/queue/queue.go
@@ -76,7 +76,7 @@ func (db *Store) nextCommand(ctx context.Context, resp mdm.Response) (*Command, 
 	case "Acknowledged":
 		// move to completed, send next
 		x, a := cut(dc.Commands, resp.CommandUUID)
-		x.Acknowledged = time.Now()
+		x.Acknowledged = time.Now().UTC()
 		dc.Commands = a
 		if x == nil {
 			break


### PR DESCRIPTION
quick resolve for https://github.com/micromdm/micromdm/issues/580

this just ensures that each time a command is moved to completed it's time is recorded in the struct.  useful to prune completed commands by date.