### PR TITLE
mdmctl: add options to sign a profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [v1.6.0](https://github.com/micromdm/micromdm/compare/v1.4.0...1.5.0) TBD
 * Add support for User Enrollment (#597)
+* Add support for Signing Profiles (#602)
 
 ## [v1.5.0](https://github.com/micromdm/micromdm/compare/v1.4.0...1.5.0) June 15 2019
 

--- a/docs/user-guide/enrolling-devices.md
+++ b/docs/user-guide/enrolling-devices.md
@@ -41,7 +41,7 @@ curl -o enroll.mobileconfig https://mdm.acme.co/mdm/enroll
 ```
 
 Next, use a text editor to modify the payload. 
-You can also [sign](https://github.com/micromdm/micromdm/wiki/Sign-the-enrollment-profile-with-Hancock) the profile. 
+You can also [sign](./mdmctl-signing-profiles.md) the profile. 
 
 Once modified and signed, you can replace the default. 
 

--- a/docs/user-guide/mdmctl-signing-profiles.md
+++ b/docs/user-guide/mdmctl-signing-profiles.md
@@ -1,0 +1,33 @@
+# Overview
+
+The MicroMDM server does not composite or sign profiles for you. Instead, it gives you the option of providing a profile which you have signed through an external process, before uploading it to the server. 
+To make signing easier, MicroMDM adds the option to sign the profile as part of the `mdmctl` tool. 
+First, you will need a private key and certificate. Any certificate will do, but to be verified on the device, you should choose one that is trusted on the devices where you're sending the payloads. The `Developer ID` certificates from Apple are examples of trusted certificates. 
+
+# Signing with mdmctl
+
+The `mdmctl apply profiles` command is used to upload a new configuration profile to the server. It can also be used to sign a profile. 
+First, run `mdmctl apply profiles -help` to see all the available command line flags. 
+
+Example command to sign a profile before uploading it to the server:
+```
+    mdmctl apply profiles \
+        -f /path/to/profile.mobileconfig \
+        -private-key /path/to/key.pem \
+        -cert /path/to/certificate.pem \
+        -password=private_key_password \
+        -sign 
+```
+
+You can also specify the `-out /path/to/signed_output.mobileconfig` to save the signed output locally, instead of uploading it to the server. 
+Using `-out -` will print the signed contents to the standard output, allowing you to pipe the output to another operation. 
+
+# Signing with other tools
+
+You can use the `security` command on the Mac to sign configuration profiles with a certificate stored in the Keychain. 
+Example:
+```
+usr/bin/security cms -S -N 'Your KeyChain Cert' -i profile.mobileconfig -o signed.mobileconfig
+```
+
+Another popular choice is Jeremy Agostino's [Hancock](https://github.com/JeremyAgost/Hancock), a GUI utility for signing profiles and packages. 

--- a/pkg/crypto/profileutil/sign.go
+++ b/pkg/crypto/profileutil/sign.go
@@ -1,0 +1,25 @@
+// Package profileutil signs configuration profiles.
+package profileutil
+
+import (
+	"crypto"
+	"crypto/x509"
+
+	"github.com/fullsailor/pkcs7"
+	"github.com/pkg/errors"
+)
+
+// Sign takes an unsigned payload and signs it with the provided private key and certificate.
+func Sign(key crypto.PrivateKey, cert *x509.Certificate, mobileconfig []byte) ([]byte, error) {
+	sd, err := pkcs7.NewSignedData(mobileconfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "create signed data for mobileconfig")
+	}
+
+	if err := sd.AddSigner(cert, key, pkcs7.SignerInfoConfig{}); err != nil {
+		return nil, errors.Wrap(err, "add crypto signer to mobileconfig signed data")
+	}
+
+	signedMobileconfig, err := sd.Finish()
+	return signedMobileconfig, errors.Wrap(err, "complete mobileconfig signing")
+}


### PR DESCRIPTION
```
mdmctl apply profiles -help

Upload profiles to the server.

Uploaded profiles can also be specified in a blueprint, which will be applied on device enrollment.
This command can also be used to replace the enrollment profile.
Profiles can be signed before upload.

Examples

  # Upload a mobileconfig
  mdmctl apply profiles -f /path/to/profile.mobileconfig

  # Sign and upload
  mdmctl apply profiles -f /path/to/profile.mobileconfig -private-key key.pem -cert certificate.pem -password secret -sign

  # Sign and save to local directory instead of uploading
  # Use "-out -" print the output to stdout instead of a file.
  mdmctl apply profiles -f /path/to/profile.mobileconfig -private-key key.pem -cert certificate.pem -password secret -sign -out signed.mobileconfig


USAGE
  mdmctl apply profiles [flags]

FLAGS
  -cert          Path to the signing certificate or p12 file.
  -f             Path to profile payload.
  -out           Output path for signed profile(optional).
  -password      Password to encrypt/read the signing key(optional) or p12 file.
  -private-key   Path to the signing private key. Don't use with p12 file.
  -sign false    Sign the profile. Requires key and certificate path.
```