### PR TITLE
allowed csr creation without a config file; added min macOS version f…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,10 @@ else
 endif
 
 export GO111MODULE=on
-CGO_CFLAGS=-mmacosx-version-min=10.12 
+
+#Specify a minimum version for macos otherwise notarization will fail
 CGO_LDFLAGS=-mmacosx-version-min=10.12 
+
 VERSION = $(shell git describe --tags --always --dirty)
 BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
 REVISION = $(shell git rev-parse HEAD)

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ else
 endif
 
 export GO111MODULE=on
-
+CGO_CFLAGS=-mmacosx-version-min=10.12 
+CGO_LDFLAGS=-mmacosx-version-min=10.12 
 VERSION = $(shell git describe --tags --always --dirty)
 BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
 REVISION = $(shell git rev-parse HEAD)

--- a/cmd/mdmctl/mdmcert.go
+++ b/cmd/mdmctl/mdmcert.go
@@ -170,7 +170,7 @@ func (cmd *mdmcertCommand) runPush(args []string) error {
 		flCN       = flagset.String("cn", "micromdm-user", "CommonName for the CSR Subject.")
 		flPKeyPass = flagset.String("password", "", "Password to encrypt/read the RSA key.")
 		flKeyPath  = flagset.String("private-key", filepath.Join(mdmcertdir, pushCertificatePrivateKeyFilename), "Path to the push certificate private key. A new RSA key will be created at this path.")
-		flNoLogging	 = flagset.Bool("nolog",false,"Does not log request to server so not configuration file required.")
+		flLocalOnly= flagset.Bool("local-only",false,"No server configuration required.")
 
 		flCSRPath = flagset.String("out", filepath.Join(mdmcertdir, pushCSRFilename), "Path to save the MDM Push Certificate request.")
 	)
@@ -179,7 +179,7 @@ func (cmd *mdmcertCommand) runPush(args []string) error {
 		return err
 	}
 
-    if !*flNoLogging {
+    if !*flLocalOnly {
         if err := cmd.setup(); err != nil {
     		return err
    		}

--- a/cmd/mdmctl/mdmcert.go
+++ b/cmd/mdmctl/mdmcert.go
@@ -72,10 +72,6 @@ func (cmd *mdmcertCommand) Run(args []string) error {
 		os.Exit(1)
 	}
 
-	if err := cmd.setup(); err != nil {
-		return err
-	}
-
 	var run func([]string) error
 	switch strings.ToLower(args[0]) {
 	case "vendor":
@@ -102,6 +98,11 @@ const (
 )
 
 func (cmd *mdmcertCommand) runVendor(args []string) error {
+    
+    if err := cmd.setup(); err != nil {
+		return err
+	}
+	
 	flagset := flag.NewFlagSet("vendor", flag.ExitOnError)
 	flagset.Usage = usageFor(flagset, "mdmctl mdmcert vendor [flags]")
 	var (
@@ -169,6 +170,7 @@ func (cmd *mdmcertCommand) runPush(args []string) error {
 		flCN       = flagset.String("cn", "micromdm-user", "CommonName for the CSR Subject.")
 		flPKeyPass = flagset.String("password", "", "Password to encrypt/read the RSA key.")
 		flKeyPath  = flagset.String("private-key", filepath.Join(mdmcertdir, pushCertificatePrivateKeyFilename), "Path to the push certificate private key. A new RSA key will be created at this path.")
+		flNoLogging	 = flagset.Bool("nolog",false,"Does not log request to server so not configuration file required.")
 
 		flCSRPath = flagset.String("out", filepath.Join(mdmcertdir, pushCSRFilename), "Path to save the MDM Push Certificate request.")
 	)
@@ -177,6 +179,11 @@ func (cmd *mdmcertCommand) runPush(args []string) error {
 		return err
 	}
 
+    if !*flNoLogging {
+        if err := cmd.setup(); err != nil {
+    		return err
+   		}
+	}
 	if err := os.MkdirAll(filepath.Dir(*flCSRPath), 0755); err != nil {
 		errors.Wrapf(err, "create directory %s", filepath.Dir(*flCSRPath))
 	}
@@ -200,6 +207,10 @@ func (cmd *mdmcertCommand) runPush(args []string) error {
 }
 
 func (cmd *mdmcertCommand) runUpload(args []string) error {
+    
+    if err := cmd.setup(); err != nil {
+		return err
+	}
 	flagset := flag.NewFlagSet("upload", flag.ExitOnError)
 	flagset.Usage = usageFor(flagset, "mdmctl mdmcert upload [flags]")
 	var (

--- a/cmd/mdmctl/mdmcert.go
+++ b/cmd/mdmctl/mdmcert.go
@@ -98,11 +98,11 @@ const (
 )
 
 func (cmd *mdmcertCommand) runVendor(args []string) error {
-    
-    if err := cmd.setup(); err != nil {
+
+	if err := cmd.setup(); err != nil {
 		return err
 	}
-	
+
 	flagset := flag.NewFlagSet("vendor", flag.ExitOnError)
 	flagset.Usage = usageFor(flagset, "mdmctl mdmcert vendor [flags]")
 	var (
@@ -165,12 +165,12 @@ func (cmd *mdmcertCommand) runPush(args []string) error {
 	flagset := flag.NewFlagSet("push", flag.ExitOnError)
 	flagset.Usage = usageFor(flagset, "mdmctl mdmcert push [flags]")
 	var (
-		flEmail    = flagset.String("email", "", "Email address to use in CSR Subject.")
-		flCountry  = flagset.String("country", "US", "Two letter country code for the CSR Subject(Example: US).")
-		flCN       = flagset.String("cn", "micromdm-user", "CommonName for the CSR Subject.")
-		flPKeyPass = flagset.String("password", "", "Password to encrypt/read the RSA key.")
-		flKeyPath  = flagset.String("private-key", filepath.Join(mdmcertdir, pushCertificatePrivateKeyFilename), "Path to the push certificate private key. A new RSA key will be created at this path.")
-		flLocalOnly= flagset.Bool("local-only",false,"No server configuration required.")
+		flEmail     = flagset.String("email", "", "Email address to use in CSR Subject.")
+		flCountry   = flagset.String("country", "US", "Two letter country code for the CSR Subject(Example: US).")
+		flCN        = flagset.String("cn", "micromdm-user", "CommonName for the CSR Subject.")
+		flPKeyPass  = flagset.String("password", "", "Password to encrypt/read the RSA key.")
+		flKeyPath   = flagset.String("private-key", filepath.Join(mdmcertdir, pushCertificatePrivateKeyFilename), "Path to the push certificate private key. A new RSA key will be created at this path.")
+		flLocalOnly = flagset.Bool("local-only", false, "No server configuration required.")
 
 		flCSRPath = flagset.String("out", filepath.Join(mdmcertdir, pushCSRFilename), "Path to save the MDM Push Certificate request.")
 	)
@@ -179,10 +179,10 @@ func (cmd *mdmcertCommand) runPush(args []string) error {
 		return err
 	}
 
-    if !*flLocalOnly {
-        if err := cmd.setup(); err != nil {
-    		return err
-   		}
+	if !*flLocalOnly {
+		if err := cmd.setup(); err != nil {
+			return err
+		}
 	}
 	if err := os.MkdirAll(filepath.Dir(*flCSRPath), 0755); err != nil {
 		errors.Wrapf(err, "create directory %s", filepath.Dir(*flCSRPath))
@@ -207,8 +207,8 @@ func (cmd *mdmcertCommand) runPush(args []string) error {
 }
 
 func (cmd *mdmcertCommand) runUpload(args []string) error {
-    
-    if err := cmd.setup(); err != nil {
+
+	if err := cmd.setup(); err != nil {
 		return err
 	}
 	flagset := flag.NewFlagSet("upload", flag.ExitOnError)


### PR DESCRIPTION
when integrating micromdm into the MDS app, i found a couple of things that would make integration with apps easier:

1. The build file should specify a minimum macOS build number or else notarization will fail since the MachO binary won't have that value.

2. Generating a CSR request doesn't require the server component expect for logging. I wanted to use the CSR generation in mdmctl, but don't want to create a configuration file. So I added in a nolog flag that doesn't require talking to the server. To do this, I had to move setup for the other operations into each command.