### PR TITLE
Add DEPProfileStatus to API response

### DIFF
--- a/platform/device/get_devices.go
+++ b/platform/device/get_devices.go
@@ -19,10 +19,11 @@ type ListDevicesOption struct {
 }
 
 type DeviceDTO struct {
-	SerialNumber     string    `json:"serial_number"`
-	UDID             string    `json:"udid"`
-	EnrollmentStatus bool      `json:"enrollment_status"`
-	LastSeen         time.Time `json:"last_seen"`
+	SerialNumber     string           `json:"serial_number"`
+	UDID             string           `json:"udid"`
+	EnrollmentStatus bool             `json:"enrollment_status"`
+	LastSeen         time.Time        `json:"last_seen"`
+	DEPProfileStatus DEPProfileStatus `json:"dep_profile_status"`
 }
 
 func (svc *DeviceService) ListDevices(ctx context.Context, opt ListDevicesOption) ([]DeviceDTO, error) {
@@ -34,6 +35,7 @@ func (svc *DeviceService) ListDevices(ctx context.Context, opt ListDevicesOption
 			UDID:             d.UDID,
 			EnrollmentStatus: d.Enrolled,
 			LastSeen:         d.LastSeen,
+			DEPProfileStatus: d.DEPProfileStatus,
 		})
 	}
 	return dto, err


### PR DESCRIPTION
Right now this doesn't work - but it should from what I can see. Opening this PR so we can get this working.

This actually returns
```
{
  "devices": [
    {
      "serial_number": "SERIAL",
      "udid": "UDID",
      "enrollment_status": true,
      "last_seen": "2019-09-05T01:32:33.994054Z",
      "dep_profile_status": ""
    }
  ]
}
```

But I would expect it to default to `empty` looking at https://github.com/micromdm/micromdm/blob/master/platform/device/device.go#L45-L53