### PR TITLE
Add option to opt out of saving device command history

### DIFF
--- a/cmd/micromdm/serve.go
+++ b/cmd/micromdm/serve.go
@@ -83,6 +83,7 @@ func serve(args []string) error {
 		flCommandWebhookURL  = flagset.String("command-webhook-url", env.String("MICROMDM_WEBHOOK_URL", ""), "URL to send command responses")
 		flHomePage           = flagset.Bool("homepage", env.Bool("MICROMDM_HTTP_HOMEPAGE", true), "Hosts a simple built-in webpage at the / address")
 		flSCEPClientValidity = flagset.Int("scep-client-validity", env.Int("MICROMDM_SCEP_CLIENT_VALIDITY", 365), "Sets the scep certificate validity in days")
+		flNoCmdHistory       = flagset.Bool("no-command-history", env.Bool("MICROMDM_NO_COMMAND_HISTORY", false), "disables saving of command history")
 		flPrintArgs          = flagset.Bool("print-flags", false, "Print all flags and their values")
 	)
 	flagset.Usage = usageFor(flagset, "micromdm serve [flags]")
@@ -125,6 +126,7 @@ func serve(args []string) error {
 		Depsim:            *flDepSim,
 		TLSCertPath:       *flTLSCert,
 		CommandWebhookURL: *flCommandWebhookURL,
+		NoCmdHistory:      *flNoCmdHistory,
 
 		WebhooksHTTPClient: &http.Client{Timeout: time.Second * 30},
 

--- a/server/server.go
+++ b/server/server.go
@@ -53,6 +53,7 @@ type Server struct {
 	CommandWebhookURL  string
 	DEPClient          *dep.Client
 	SyncDB             *syncbuiltin.DB
+	NoCmdHistory       bool
 
 	APNSPushService apns.Service
 	CommandService  command.Service
@@ -158,7 +159,11 @@ func (c *Server) setupCommandService() error {
 }
 
 func (c *Server) setupCommandQueue(logger log.Logger) error {
-	q, err := queue.NewQueue(c.DB, c.PubClient, queue.WithLogger(logger))
+	opts := []queue.Option{queue.WithLogger(logger)}
+	if c.NoCmdHistory {
+		opts = append(opts, queue.WithoutHistory())
+	}
+	q, err := queue.NewQueue(c.DB, c.PubClient, opts...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
MicroMDM currently saves all commands it has sent. Further, it stores these on a single device record in the database. This has lead to scalability issue that creates a race condition as noted in #556. This PR creates an option to simply skip saving these historical commands to the database.