### PR TITLE
dynamic SCEP challenge support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 ## [v1.7.0](https://github.com/micromdm/micromdm/compare/v1.6.0...master) TBD
 
+### Reliability, scalability, security, and usability improvements:
+
 * Add device DEP status to API response (#617)
 * CLI improvements (#618, #620, #621)
 * Support new values for AccountConfiguration (#627)
 * Fix issue where DEP watcher would stop permanently for transient network issues  (#582, #632)
 * Workaround issue where a newly added DEP token would not be used after a restart (#546, #633)
+* Fix bug with applying an empty blueprint (#615, #634)
+* Add `-no-command-history` flag to disable saving of command history (#640). This works around a race-condition/scalability issue with device records (#556).
+* Add dynamic SCEP challenges (#642). Require dynamic SCEP challenges for certificate issuance with `-use-dynamic-challege` and (only recommended for testing) generate them in enrollment profiles with `-gen-dynamic-challege`.
 
 Thanks to our contributors for this release: @grahamgilbert, @n8felton
 

--- a/cmd/micromdm/serve.go
+++ b/cmd/micromdm/serve.go
@@ -124,20 +124,20 @@ func serve(args []string) error {
 		return errors.Wrapf(err, "creating config directory %s", *flConfigPath)
 	}
 	sm := &server.Server{
-		ConfigPath:        *flConfigPath,
-		ServerPublicURL:   strings.TrimRight(*flServerURL, "/"),
-		Depsim:            *flDepSim,
-		TLSCertPath:       *flTLSCert,
-		CommandWebhookURL: *flCommandWebhookURL,
-		NoCmdHistory:      *flNoCmdHistory,
-		UseDynSCEPChal:    *flUseDynChallenge,
-		GenDynSCEPChal:    *flGenDynChalEnroll,
+		ConfigPath:          *flConfigPath,
+		ServerPublicURL:     strings.TrimRight(*flServerURL, "/"),
+		Depsim:              *flDepSim,
+		TLSCertPath:         *flTLSCert,
+		CommandWebhookURL:   *flCommandWebhookURL,
+		NoCmdHistory:        *flNoCmdHistory,
+		UseDynSCEPChallenge: *flUseDynChallenge,
+		GenDynSCEPChallenge: *flGenDynChalEnroll,
 
 		WebhooksHTTPClient: &http.Client{Timeout: time.Second * 30},
 
 		SCEPClientValidity: *flSCEPClientValidity,
 	}
-	if !sm.UseDynSCEPChal {
+	if !sm.UseDynSCEPChallenge {
 		// TODO: we have a static SCEP challenge password here to prevent
 		// being prompted for the SCEP challenge which happens in a "normal"
 		// (non-DEP) enrollment. While security is not improved it is at least

--- a/cmd/micromdm/serve.go
+++ b/cmd/micromdm/serve.go
@@ -34,6 +34,7 @@ import (
 	appsbuiltin "github.com/micromdm/micromdm/platform/appstore/builtin"
 	"github.com/micromdm/micromdm/platform/blueprint"
 	blueprintbuiltin "github.com/micromdm/micromdm/platform/blueprint/builtin"
+	"github.com/micromdm/micromdm/platform/challenge"
 	"github.com/micromdm/micromdm/platform/command"
 	"github.com/micromdm/micromdm/platform/config"
 	depapi "github.com/micromdm/micromdm/platform/dep"
@@ -84,6 +85,8 @@ func serve(args []string) error {
 		flHomePage           = flagset.Bool("homepage", env.Bool("MICROMDM_HTTP_HOMEPAGE", true), "Hosts a simple built-in webpage at the / address")
 		flSCEPClientValidity = flagset.Int("scep-client-validity", env.Int("MICROMDM_SCEP_CLIENT_VALIDITY", 365), "Sets the scep certificate validity in days")
 		flNoCmdHistory       = flagset.Bool("no-command-history", env.Bool("MICROMDM_NO_COMMAND_HISTORY", false), "disables saving of command history")
+		flUseDynChallenge    = flagset.Bool("use-dynamic-challege", env.Bool("MICROMDM_USE_DYNAMIC_CHALLENGE", false), "require dynamic SCEP challenges")
+		flGenDynChalEnroll   = flagset.Bool("gen-dynamic-challege", env.Bool("MICROMDM_GEN_DYNAMIC_CHALLENGE", false), "generate dynamic SCEP challenges in enrollment profile (built-in only)")
 		flPrintArgs          = flagset.Bool("print-flags", false, "Print all flags and their values")
 	)
 	flagset.Usage = usageFor(flagset, "micromdm serve [flags]")
@@ -127,15 +130,19 @@ func serve(args []string) error {
 		TLSCertPath:       *flTLSCert,
 		CommandWebhookURL: *flCommandWebhookURL,
 		NoCmdHistory:      *flNoCmdHistory,
+		UseDynSCEPChal:    *flUseDynChallenge,
+		GenDynSCEPChal:    *flGenDynChalEnroll,
 
 		WebhooksHTTPClient: &http.Client{Timeout: time.Second * 30},
 
+		SCEPClientValidity: *flSCEPClientValidity,
+	}
+	if !sm.UseDynSCEPChal {
 		// TODO: we have a static SCEP challenge password here to prevent
 		// being prompted for the SCEP challenge which happens in a "normal"
 		// (non-DEP) enrollment. While security is not improved it is at least
 		// no less secure and prevents a useless dialog from showing.
-		SCEPChallenge:      "micromdm",
-		SCEPClientValidity: *flSCEPClientValidity,
+		sm.SCEPChallenge = "micromdm"
 	}
 
 	if err := sm.Setup(logger); err != nil {
@@ -259,6 +266,9 @@ func serve(args []string) error {
 
 		depsyncEndpoints := sync.MakeServerEndpoints(sync.NewService(syncer, sm.SyncDB), basicAuthEndpointMiddleware)
 		sync.RegisterHTTPHandlers(r, depsyncEndpoints, options...)
+
+		challengeEndpoints := challenge.MakeServerEndpoints(challenge.NewService(sm.SCEPChallengeDepot), basicAuthEndpointMiddleware)
+		challenge.RegisterHTTPHandlers(r, challengeEndpoints, options...)
 
 		r.HandleFunc("/boltbackup", httputil2.RequireBasicAuth(boltBackup(sm.DB), "micromdm", *flAPIKey, "micromdm"))
 	} else {

--- a/platform/challenge/challenge.go
+++ b/platform/challenge/challenge.go
@@ -1,0 +1,22 @@
+package challenge
+
+import (
+	"context"
+
+	"github.com/go-kit/kit/endpoint"
+)
+
+type challengeResponse struct {
+	Challenge string `json:"string"`
+	Err       error  `json:"err,omitempty"`
+}
+
+func (r challengeResponse) Failed() error { return r.Err }
+
+func MakeChallengeEndpoint(svc Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (response interface{}, err error) {
+		r := challengeResponse{}
+		r.Challenge, r.Err = svc.SCEPChallenge(ctx)
+		return r, nil
+	}
+}

--- a/platform/challenge/server.go
+++ b/platform/challenge/server.go
@@ -1,0 +1,36 @@
+package challenge
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/go-kit/kit/endpoint"
+	httptransport "github.com/go-kit/kit/transport/http"
+	"github.com/gorilla/mux"
+	"github.com/micromdm/micromdm/pkg/httputil"
+)
+
+type Endpoints struct {
+	ChallengeEndpoint endpoint.Endpoint
+}
+
+func MakeServerEndpoints(s Service, outer endpoint.Middleware, others ...endpoint.Middleware) Endpoints {
+	return Endpoints{
+		ChallengeEndpoint: endpoint.Chain(outer, others...)(MakeChallengeEndpoint(s)),
+	}
+}
+
+func RegisterHTTPHandlers(r *mux.Router, e Endpoints, options ...httptransport.ServerOption) {
+	// POST   /v1/challenge    Generate and return SCEP challenge
+
+	r.Methods("POST").Path("/v1/challenge").Handler(httptransport.NewServer(
+		e.ChallengeEndpoint,
+		decodeEmptyRequest,
+		httputil.EncodeJSONResponse,
+		options...,
+	))
+}
+
+func decodeEmptyRequest(ctx context.Context, r *http.Request) (interface{}, error) {
+	return nil, nil
+}

--- a/platform/challenge/service.go
+++ b/platform/challenge/service.go
@@ -1,0 +1,24 @@
+package challenge
+
+import (
+	"context"
+	challengestore "github.com/micromdm/scep/challenge/bolt"
+)
+
+type Service interface {
+	SCEPChallenge(ctx context.Context) (string, error)
+}
+
+type ChallengeService struct {
+	scepChallengeStore *challengestore.Depot
+}
+
+func (c *ChallengeService) SCEPChallenge(ctx context.Context) (string, error) {
+	return c.scepChallengeStore.SCEPChallenge()
+}
+
+func NewService(cs *challengestore.Depot) *ChallengeService {
+	return &ChallengeService{
+		scepChallengeStore: cs,
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -39,25 +39,25 @@ import (
 )
 
 type Server struct {
-	ConfigPath         string
-	Depsim             string
-	PubClient          pubsub.PublishSubscriber
-	DB                 *bolt.DB
-	ServerPublicURL    string
-	SCEPChallenge      string
-	SCEPClientValidity int
-	TLSCertPath        string
-	SCEPDepot          *boltdepot.Depot
-	UseDynSCEPChal     bool
-	GenDynSCEPChal     bool
-	SCEPChallengeDepot *challengestore.Depot
-	ProfileDB          profile.Store
-	ConfigDB           config.Store
-	RemoveDB           block.Store
-	CommandWebhookURL  string
-	DEPClient          *dep.Client
-	SyncDB             *syncbuiltin.DB
-	NoCmdHistory       bool
+	ConfigPath          string
+	Depsim              string
+	PubClient           pubsub.PublishSubscriber
+	DB                  *bolt.DB
+	ServerPublicURL     string
+	SCEPChallenge       string
+	SCEPClientValidity  int
+	TLSCertPath         string
+	SCEPDepot           *boltdepot.Depot
+	UseDynSCEPChallenge bool
+	GenDynSCEPChallenge bool
+	SCEPChallengeDepot  *challengestore.Depot
+	ProfileDB           profile.Store
+	ConfigDB            config.Store
+	RemoveDB            block.Store
+	CommandWebhookURL   string
+	DEPClient           *dep.Client
+	SyncDB              *syncbuiltin.DB
+	NoCmdHistory        bool
 
 	APNSPushService apns.Service
 	CommandService  command.Service
@@ -247,7 +247,7 @@ func (c *Server) setupEnrollmentService() error {
 	)
 
 	chalStore := c.SCEPChallengeDepot
-	if !c.GenDynSCEPChal {
+	if !c.GenDynSCEPChallenge {
 		chalStore = nil
 	}
 
@@ -356,7 +356,7 @@ func (c *Server) setupSCEP(logger log.Logger) error {
 		scep.ClientValidity(c.SCEPClientValidity),
 	}
 	var scepChalOpt scep.ServiceOption
-	if c.UseDynSCEPChal {
+	if c.UseDynSCEPChallenge {
 		c.SCEPChallengeDepot, err = challengestore.NewBoltDepot(c.DB)
 		if err != nil {
 			return err

--- a/server/server.go
+++ b/server/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/boltdb/bolt"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	challengestore "github.com/micromdm/scep/challenge/bolt"
 	boltdepot "github.com/micromdm/scep/depot/bolt"
 	scep "github.com/micromdm/scep/server"
 	"github.com/pkg/errors"
@@ -47,6 +48,9 @@ type Server struct {
 	SCEPClientValidity int
 	TLSCertPath        string
 	SCEPDepot          *boltdepot.Depot
+	UseDynSCEPChal     bool
+	GenDynSCEPChal     bool
+	SCEPChallengeDepot *challengestore.Depot
 	ProfileDB          profile.Store
 	ConfigDB           config.Store
 	RemoveDB           block.Store
@@ -241,6 +245,12 @@ func (c *Server) setupEnrollmentService() error {
 		SCEPCertificateSubject string
 		err                    error
 	)
+
+	chalStore := c.SCEPChallengeDepot
+	if !c.GenDynSCEPChal {
+		chalStore = nil
+	}
+
 	// TODO: clean up order of inputs. Maybe pass *SCEPConfig as an arg?
 	// but if you do, the packages are coupled, better not.
 	c.EnrollService, err = enroll.NewService(
@@ -252,6 +262,7 @@ func (c *Server) setupEnrollmentService() error {
 		c.TLSCertPath,
 		SCEPCertificateSubject,
 		c.ProfileDB,
+		chalStore,
 	)
 	return errors.Wrap(err, "setting up enrollment service")
 }
@@ -343,8 +354,18 @@ func (c *Server) setupSCEP(logger log.Logger) error {
 
 	opts := []scep.ServiceOption{
 		scep.ClientValidity(c.SCEPClientValidity),
-		scep.ChallengePassword(c.SCEPChallenge),
 	}
+	var scepChalOpt scep.ServiceOption
+	if c.UseDynSCEPChal {
+		c.SCEPChallengeDepot, err = challengestore.NewBoltDepot(c.DB)
+		if err != nil {
+			return err
+		}
+		scepChalOpt = scep.WithDynamicChallenges(c.SCEPChallengeDepot)
+	} else {
+		scepChalOpt = scep.ChallengePassword(c.SCEPChallenge)
+	}
+	opts = append(opts, scepChalOpt)
 	c.SCEPDepot = depot
 	c.SCEPService, err = scep.NewService(depot, opts...)
 	if err != nil {


### PR DESCRIPTION
This integrates optional dynamic SCEP challenge support. This means that the MicroMDM SCEP server will require a pre-generated random SCEP challenge before issuing a certificate (and thus allowing enrollment into MDM) if the `-use-dynamic-challege` is set. In order for a device to successfully enroll using this method the SCEP challenge must be present in the enrollment profile SCEP payload that is sent to the device. Think of it like an enrollment passcode.

To generate your own enrollment profiles you'll want to use this new API endpoint of `/v1/challenge` which generates, stores, and returns the one-time SCEP challenge which should be embedded in an enrollment profile.

Interestingly, the SCEP server code for this has been written for quite some time (thanks, @groob!). I believe this hadn't been integrated yet because the security value was debatable in that enrollment profiles are automatically generated by MicroMDM for MDM, OTA, and profile enrollments. If profiles (and thus challenges) are simply provided in the profile the the point of even having the challenges is lessened (as there's nothing authenticating the use of a SCEP challenge). However with macOS 10.15 Catalina and iOS 13 we now have a DEP capable way of doing modern authentication and thus proper gating of the enrollment profile (and any sensitive content, like a SCEP payload challenge).

That said this brings up some options of how we want to handle this feature. I see a couple options forward:

1. Require the administrator to completely handle the profile service. For dynamic SCEP challenges to work, generally, something has to dynamically compose enrollment profiles with SCEP challenges embedded in them. This is a lot of logic, presumably on top of an authentication system to handle. It means, basically, standing up another service to handle the enrollment profile delivery. 
2. Implement an optional webbook/callback for the enrollment profile service. I.e. when `/mdm/enroll` is hit, we, essentially, proxy that request to another URL much like # 1 above. This has the benefit that we can still handle some of the lower-level client validation (like PKCS#7 certificate verification on the OTA and DEP enrollment requests) while handing handling the profile generation off to another service.
3. Implement dynamic SCEP challenge profile creation. There's two (minimalist) ways to do this, I see:
   1. For MicroMDM-generated profiles, simply insert the SCEP challenge as we've been doing for non-dynamic SCEP challenges. This means that for anything more involved as an administrator you have to figure out e.g. # 1 above.
   2. Do a simple find-and-replace on any locally generated or stored enrollment profile for a value such as "${SCEP_CHALLENGE}". This has the benefit of working for stored enrollment profiles (i.e. those that an admin has modified) as well as the defaul (generated) profile.

When thinking about this we should make a delineation between "legacy" enrollment endpoints (OTA, "old" DEP, profile endpoint) and new Web view iOS 13/Catalina enrollments. If we optimize for the latter then # 1 seems more appropriate.

Currently, this PR implements 3i above with an optional parameter of `-gen-dynamic-challege` (otherwise, it doesn't mess with the enrollment profile and you're back to situation # 1, above: doing it yourself). I feel like this is a nice compromise of turning it on quickly for experimentation, and having to do everything yourself right off the bat with # 1.

Anyway I'm interested in any feedback!