### PR TITLE
UDID Cert Auth: warn only option

### DIFF
--- a/cmd/micromdm/serve.go
+++ b/cmd/micromdm/serve.go
@@ -88,6 +88,7 @@ func serve(args []string) error {
 		flUseDynChallenge        = flagset.Bool("use-dynamic-challenge", env.Bool("MICROMDM_USE_DYNAMIC_CHALLENGE", false), "require dynamic SCEP challenges")
 		flGenDynChalEnroll       = flagset.Bool("gen-dynamic-challenge", env.Bool("MICROMDM_GEN_DYNAMIC_CHALLENGE", false), "generate dynamic SCEP challenges in enrollment profile (built-in only)")
 		flValidateSCEPIssuer     = flagset.Bool("validate-scep-issuer", env.Bool("MICROMDM_VALIDATE_SCEP_ISSUER", false), "validate only the issuer of the SCEP certificate rather than the whole certificate")
+		flUDIDCertAuthWarnOnly   = flagset.Bool("udid-cert-auth-warn-only", env.Bool("MICROMDM_UDID_CERT_AUTH_WARN_ONLY", false), "warn only for udid cert mismatches")
 		flValidateSCEPExpiration = flagset.Bool("validate-scep-expiration", env.Bool("MICROMDM_VALIDATE_SCEP_EXPIRATION", false), "validate that the SCEP certificate is still valid")
 		flPrintArgs              = flagset.Bool("print-flags", false, "Print all flags and their values")
 	)
@@ -135,6 +136,7 @@ func serve(args []string) error {
 		UseDynSCEPChallenge:    *flUseDynChallenge,
 		GenDynSCEPChallenge:    *flGenDynChalEnroll,
 		ValidateSCEPIssuer:     *flValidateSCEPIssuer,
+		UDIDCertAuthWarnOnly:   *flUDIDCertAuthWarnOnly,
 		ValidateSCEPExpiration: *flValidateSCEPExpiration,
 
 		WebhooksHTTPClient: &http.Client{Timeout: time.Second * 30},

--- a/server/server.go
+++ b/server/server.go
@@ -60,6 +60,7 @@ type Server struct {
 	NoCmdHistory           bool
 	ValidateSCEPIssuer     bool
 	ValidateSCEPExpiration bool
+	UDIDCertAuthWarnOnly   bool
 
 	APNSPushService apns.Service
 	CommandService  command.Service
@@ -185,7 +186,7 @@ func (c *Server) setupCommandQueue(logger log.Logger) error {
 		mdmService = block.RemoveMiddleware(c.RemoveDB)(mdmService)
 
 		udidauthLogger := log.With(logger, "component", "udidcertauth")
-		mdmService = device.UDIDCertAuthMiddleware(devDB, udidauthLogger)(mdmService)
+		mdmService = device.UDIDCertAuthMiddleware(devDB, udidauthLogger, c.UDIDCertAuthWarnOnly)(mdmService)
 
 		verifycertLogger := log.With(logger, "component", "verifycert")
 		mdmService = VerifyCertificateMiddleware(c.ValidateSCEPIssuer, c.ValidateSCEPExpiration, c.SCEPDepot, verifycertLogger)(mdmService)


### PR DESCRIPTION
Currently the UDID Cert Auth middleware (#358) rejects connections for mismatched certificates. However, if you have a legitimate reason to allow non-matching certificates (say, you have active enrollments for which [end-users renewed their own certificates](https://github.com/micromdm/micromdm/wiki/Device-Identity-Certificate-Expiration)) you may want to disable the connection rejection while you remediate those enrollments.

I'm not entirely convinced this should even be merged as it actively subverts a security measure. Thoughts welcome.