### PR TITLE
Revert "Correct SCEP profile payload (#492)"

### DIFF
--- a/mdm/enroll/profile.go
+++ b/mdm/enroll/profile.go
@@ -59,8 +59,8 @@ type SCEPPayloadContent struct {
 	CAFingerprint []byte `plist:"CAFingerprint,omitempty"` // NSData
 	Challenge     string `plist:"Challenge,omitempty"`
 	Keysize       int
-	KeyType       string `plist:"KeyType"`
-	KeyUsage      int    `plist:"KeyUsage"`
+	KeyType       string `plist:"Key Type"`
+	KeyUsage      int    `plist:"Key Usage"`
 	Name          string
 	Subject       [][][]string `plist:"Subject,omitempty"`
 	URL           string


### PR DESCRIPTION
This reverts commit 2f2616e274052529d50fb7e2d655a629a205c8d1 (#492). It appears the old PDF docs were incorrect and the keys with spaces are actually correct as documented here: https://developer.apple.com/documentation/devicemanagement/scep/payloadcontent#properties