### PR TITLE
Extended the Commands endpoint to allow the caller to specify a custom UUID for the command

### DIFF
--- a/mdm/mdm/command.go
+++ b/mdm/mdm/command.go
@@ -6,7 +6,8 @@ import (
 )
 
 type CommandRequest struct {
-	UDID string `json:"udid"`
+	UDID        string  `json:"udid"`
+	CommandUUID *string `json:"command_uuid,omitempty"`
 	*Command
 }
 
@@ -16,8 +17,16 @@ type CommandPayload struct {
 }
 
 func NewCommandPayload(request *CommandRequest) (*CommandPayload, error) {
+	var CommandUUID string
+	// The `CommandUUID` parameter is optional. If it was not sent, the default behavior is to provide one randomly.
+	if request.CommandUUID != nil {
+		CommandUUID = *request.CommandUUID
+	} else {
+		CommandUUID = uuid.New().String()
+	}
+
 	payload := &CommandPayload{
-		CommandUUID: uuid.New().String(),
+		CommandUUID: CommandUUID,
 		Command:     request.Command,
 	}
 	return payload, nil

--- a/mdm/mdm/unmarshal_json.go
+++ b/mdm/mdm/unmarshal_json.go
@@ -9,13 +9,15 @@ import (
 
 func (c *CommandRequest) UnmarshalJSON(data []byte) error {
 	var request = struct {
-		UDID        string `json:"udid"`
-		RequestType string `json:"request_type"`
+		UDID        string  `json:"udid"`
+		CommandUUID *string `json:"command_uuid"`
+		RequestType string  `json:"request_type"`
 	}{}
 	if err := json.Unmarshal(data, &request); err != nil {
 		return errors.Wrap(err, "mdm: unmarshal json command request")
 	}
 	c.UDID = request.UDID
+	c.CommandUUID = request.CommandUUID
 	c.Command = &Command{}
 	return c.Command.UnmarshalJSON(data)
 }


### PR DESCRIPTION
Small modification, though this is my first contribution so please let me know about anything at all!

This is an implementation of https://github.com/micromdm/micromdm/issues/671 . This was done by adding the `CommandUUID` field to `CommandRequest` as well as adding `command_uuid` to its JSON unmarshalling procedure. 

The default behavior if no custom UUID is provided is to simply generate a random UUID. This is the same behavior as before and so no API consumers should break as a result of this change.