### PR TITLE
Updated URL to join MacAdmins Slack group

### DIFF
--- a/docs/user-guide/introduction.md
+++ b/docs/user-guide/introduction.md
@@ -1,6 +1,6 @@
 # Getting Help
 
-The best place to get help with setting up and ongoing maintenance of MicroMDM is the MacAdmins Slack. Join by getting an [invitation here](https://macadmins.herokuapp.com/).
+The best place to get help with setting up and ongoing maintenance of MicroMDM is the MacAdmins Slack. Join by getting an [invitation here](https://www.macadmins.org/).
 
 Once you join Slack, the following channels will be useful.
 - `#micromdm` for MicroMDM specific questions.


### PR DESCRIPTION
The URL to join MacAdmins Slack group was an error page at "macadmins.herokuapp.com". I assume this is the old address and should be "www.macadmins.org".