### PR TITLE
Updated mdmctl to allow base server URL to have a path

### DIFF
--- a/cmd/mdmctl/config.go
+++ b/cmd/mdmctl/config.go
@@ -207,7 +207,6 @@ func validateServerURL(serverURL string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	u.Path = "/"
 	serverURL = u.String()
 
 	return serverURL, nil

--- a/cmd/mdmctl/config.go
+++ b/cmd/mdmctl/config.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"os/user"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -207,7 +208,9 @@ func validateServerURL(serverURL string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	serverURL = u.String()
+	const tempPath = "x"
+	u.Path = path.Join(u.Path, tempPath)
+	serverURL = strings.TrimSuffix(u.String(), tempPath) // assure URL ends with "/"
 
 	return serverURL, nil
 }

--- a/cmd/mdmctl/config.go
+++ b/cmd/mdmctl/config.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"os"
 	"os/user"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -208,10 +207,7 @@ func validateServerURL(serverURL string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	const tempPath = "x"
-	u.Path = path.Join(u.Path, tempPath)
-	serverURL = strings.TrimSuffix(u.String(), tempPath) // assure URL ends with "/"
-
+	serverURL = u.String()
 	return serverURL, nil
 }
 

--- a/cmd/mdmctl/config_test.go
+++ b/cmd/mdmctl/config_test.go
@@ -3,12 +3,24 @@ package main
 import "testing"
 
 func TestValidateServerURL(t *testing.T) {
-
 	tests := []struct {
-		name     string
-		input    string
-		expected string
+		name        string
+		input       string
+		expected    string
+		errExpected bool
 	}{
+		{
+			name:        "empty",
+			input:       "",
+			expected:    "",
+			errExpected: true,
+		},
+		{
+			name:        "whitespace",
+			input:       " ",
+			expected:    "",
+			errExpected: true,
+		},
 		{
 			name:     "http",
 			input:    "http://localhost:8000",
@@ -29,10 +41,43 @@ func TestValidateServerURL(t *testing.T) {
 			input:    "localhost:8000",
 			expected: "https://localhost:8000/",
 		},
+		{
+			name:     "http_path",
+			input:    "http://localhost:8000/path",
+			expected: "http://localhost:8000/path/",
+		},
+		{
+			name:     "https_path",
+			input:    "https://localhost:8000/path",
+			expected: "https://localhost:8000/path/",
+		},
+		{
+			name:     "trailing_slash_path",
+			input:    "https://localhost:8000/path/",
+			expected: "https://localhost:8000/path/",
+		},
+		{
+			name:     "no_prefix_path",
+			input:    "localhost:8000/path",
+			expected: "https://localhost:8000/path/",
+		},
+		{
+			name:     "multipart_path",
+			input:    "https://localhost:8000/path1/path2/path3",
+			expected: "https://localhost:8000/path1/path2/path3/",
+		},
+		{
+			name:     "multipart_path_trailing_slash",
+			input:    "https://localhost:8000/longerpath1/longerpath2/longerpath3/",
+			expected: "https://localhost:8000/longerpath1/longerpath2/longerpath3/",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actualURL, _ := validateServerURL(tt.input)
+			actualURL, err := validateServerURL(tt.input)
+			if haveErr, wantErr := err != nil, tt.errExpected; haveErr != wantErr {
+				t.Errorf("have error - %t, want error - %t", haveErr, wantErr)
+			}
 			if have, want := actualURL, tt.expected; have != want {
 				t.Errorf("have %s, want %s", have, want)
 			}

--- a/cmd/mdmctl/config_test.go
+++ b/cmd/mdmctl/config_test.go
@@ -24,12 +24,12 @@ func TestValidateServerURL(t *testing.T) {
 		{
 			name:     "http",
 			input:    "http://localhost:8000",
-			expected: "http://localhost:8000/",
+			expected: "http://localhost:8000",
 		},
 		{
 			name:     "https",
 			input:    "https://localhost:8000",
-			expected: "https://localhost:8000/",
+			expected: "https://localhost:8000",
 		},
 		{
 			name:     "trailing_slash",
@@ -39,17 +39,17 @@ func TestValidateServerURL(t *testing.T) {
 		{
 			name:     "no_prefix",
 			input:    "localhost:8000",
-			expected: "https://localhost:8000/",
+			expected: "https://localhost:8000",
 		},
 		{
 			name:     "http_path",
 			input:    "http://localhost:8000/path",
-			expected: "http://localhost:8000/path/",
+			expected: "http://localhost:8000/path",
 		},
 		{
 			name:     "https_path",
 			input:    "https://localhost:8000/path",
-			expected: "https://localhost:8000/path/",
+			expected: "https://localhost:8000/path",
 		},
 		{
 			name:     "trailing_slash_path",
@@ -59,12 +59,12 @@ func TestValidateServerURL(t *testing.T) {
 		{
 			name:     "no_prefix_path",
 			input:    "localhost:8000/path",
-			expected: "https://localhost:8000/path/",
+			expected: "https://localhost:8000/path",
 		},
 		{
 			name:     "multipart_path",
 			input:    "https://localhost:8000/path1/path2/path3",
-			expected: "https://localhost:8000/path1/path2/path3/",
+			expected: "https://localhost:8000/path1/path2/path3",
 		},
 		{
 			name:     "multipart_path_trailing_slash",

--- a/pkg/httputil/httputil.go
+++ b/pkg/httputil/httputil.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 
 	"github.com/go-kit/kit/log"
@@ -103,9 +104,9 @@ func EncodeRequestWithToken(token string, next httptransport.EncodeRequestFunc) 
 	}
 }
 
-func CopyURL(base *url.URL, path string) *url.URL {
+func CopyURL(base *url.URL, appendPath string) *url.URL {
 	next := *base
-	next.Path = path
+	next.Path = path.Join(base.Path, appendPath)
 	return &next
 }
 


### PR DESCRIPTION
Updated mdmctl to allow its base server URL to have a path. For example: `https://www.example.com/test/`

The first MicroMDM server I configured required that its base URL have a path. When I set my local mdmctl server url with a path, I didn't realize mdmctl removed it. My commands failed with confusing errors. For example, `mdmctl get devices` returned "invalid character 'O' looking for beginning of value".

It took me a little while to figure out the server url path was removed. Then, I tried editing servers.json directly and added the server path. mdmctl still did not work because it removed the path again after the server URL was loaded from servers.json. This exercise took some time troubleshooting. I'd like to prevent this from happening to others.

