### PR TITLE
MarshalQueuedCommand property mismatch

### DIFF
--- a/platform/queue/command_queued.go
+++ b/platform/queue/command_queued.go
@@ -18,7 +18,7 @@ func MarshalQueuedCommand(cq *QueueCommandQueued) ([]byte, error) {
 	}
 	return proto.Marshal(&commandqueued.CommandQueued{
 		DeviceUdid:  cq.DeviceUDID,
-		CommandUuid: cq.DeviceUDID,
+		CommandUuid: cq.CommandUUID,
 	})
 }
 


### PR DESCRIPTION
When a QueueCommandQueued is marshaled in MarshalQueuedCommand, the QueueCommandQueued.DeviceUDID was copied to the protobuf CommandUuid property. Now the CommandUUID property is copied to the protobuf CommandUuid property.