### PR TITLE
fixed regression with local-only flag

### DIFF
--- a/cmd/mdmctl/mdmcert.go
+++ b/cmd/mdmctl/mdmcert.go
@@ -71,9 +71,18 @@ func (cmd *mdmcertCommand) Run(args []string) error {
 		cmd.Usage()
 		os.Exit(1)
 	}
+	
+	localonly := false
+	for _, a := range args {
+		if a == "-local-only" {
+			localonly=true
+		}
+	}
 
-	if err := cmd.setup(); err != nil {
-		return err
+	if !localonly {
+		if err := cmd.setup(); err != nil {
+			return err
+		}
 	}
 
 	var run func([]string) error


### PR DESCRIPTION
the local-only flag was added to mdmctl so that local configuration is not needed for generating a CSR. Contacting the server was only used for logging. There appears to be a regression where logging happens earlier and the local-only flag no longer works. This pull enables logging earlier only if the local-only flag is not set.