### PR TITLE
Avoid queue save when not needed

### DIFF
--- a/platform/queue/queue.go
+++ b/platform/queue/queue.go
@@ -164,6 +164,8 @@ func (db *Store) nextCommand(ctx context.Context, resp mdm.Response) (*Command, 
 		}
 	}
 
+	// we only need to Save if there are command queue changes such as
+	// NowNow and Acknowledged responses or a new popped command.
 	if resp.Status != "Idle" || cmd != nil {
 		if err := db.Save(dc); err != nil {
 			return nil, err

--- a/platform/queue/queue.go
+++ b/platform/queue/queue.go
@@ -164,8 +164,10 @@ func (db *Store) nextCommand(ctx context.Context, resp mdm.Response) (*Command, 
 		}
 	}
 
-	if err := db.Save(dc); err != nil {
-		return nil, err
+	if resp.Status != "Idle" || cmd != nil {
+		if err := db.Save(dc); err != nil {
+			return nil, err
+		}
 	}
 
 	return cmd, nil


### PR DESCRIPTION
When there's no new command and there's an `Idle` connect there's no need to re-write the queue for a device back out — nothing's changed. Saves a BoltDB write operation in that case.