### PR TITLE
Fix SetFirmwarePassword and VerifyFirmwarePassword parameters

### DIFF
--- a/mdm/mdm/command.go
+++ b/mdm/mdm/command.go
@@ -243,12 +243,12 @@ type ManagedApplicationFeedback struct {
 
 type SetFirmwarePassword struct {
 	CurrentPassword string `plist:",omitempty" json:"current_password,omitempty"`
-	NewPassword     string `plist:",omitempty" json:"new_password,omitempty"`
+	NewPassword     string `json:"new_password"`
 	AllowOroms      bool   `plist:",omitempty" json:"allow_oroms,omitempty"`
 }
 
 type VerifyFirmwarePassword struct {
-	Password string `plist:",omitempty" json:"password,omitempty"`
+	Password string `json:"password"`
 }
 
 type SetAutoAdminPassword struct {

--- a/mdm/mdm/mdm_command_test.go
+++ b/mdm/mdm/mdm_command_test.go
@@ -62,6 +62,30 @@ func TestMarshalCommand(t *testing.T) {
 				RequestType: "DisableRemoteDesktop",
 			},
 		},
+		{
+			Command: Command{
+				RequestType: "SetFirmwarePassword",
+				SetFirmwarePassword: &SetFirmwarePassword{
+					CurrentPassword: "test",
+				},
+			},
+		},
+		{
+			Command: Command{
+				RequestType: "SetFirmwarePassword",
+				SetFirmwarePassword: &SetFirmwarePassword{
+					NewPassword: "test",
+				},
+			},
+		},
+		{
+			Command: Command{
+				RequestType: "SetFirmwarePassword",
+				VerifyFirmwarePassword: &VerifyFirmwarePassword{
+					Password: "test",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.Command.RequestType+"_json", func(t *testing.T) {
@@ -215,6 +239,60 @@ func TestEndToEnd(t *testing.T) {
 					[]byte(`display-image`),
 					[]byte(`Test Title`),
 					[]byte(`Test Subtitle`),
+				}
+				for _, b := range needToSee {
+					if !bytes.Contains(parts.plistData, b) {
+						t.Error(fmt.Sprintf("marshaled plist does not contain required bytes: '%s'", string(b)))
+					}
+				}
+			},
+		},
+
+		{
+			name: "SetFirmwarePassword_NoNewPassword",
+			requestBytes: []byte(
+				`{"request_type":"SetFirmwarePassword","current_password":"test"}`,
+			),
+			testFn: func(t *testing.T, parts endToEndParts) {
+				needToSee := [][]byte{
+					[]byte(`CurrentPassword`),
+					[]byte(`test`),
+					[]byte(`NewPassword`),
+				}
+				for _, b := range needToSee {
+					if !bytes.Contains(parts.plistData, b) {
+						t.Error(fmt.Sprintf("marshaled plist does not contain required bytes: '%s'", string(b)))
+					}
+				}
+			},
+		},
+		{
+			name: "SetFirmwarePassword_NewPassword",
+			requestBytes: []byte(
+				`{"request_type":"SetFirmwarePassword","new_password":"test"}`,
+			),
+			testFn: func(t *testing.T, parts endToEndParts) {
+				needToSee := [][]byte{
+					[]byte(`NewPassword`),
+					[]byte(`test`),
+				}
+				for _, b := range needToSee {
+					if !bytes.Contains(parts.plistData, b) {
+						t.Error(fmt.Sprintf("marshaled plist does not contain required bytes: '%s'", string(b)))
+					}
+				}
+			},
+		},
+
+		{
+			name: "VerifyFirmwarePassword",
+			requestBytes: []byte(
+				`{"request_type":"VerifyFirmwarePassword","password":"test"}`,
+			),
+			testFn: func(t *testing.T, parts endToEndParts) {
+				needToSee := [][]byte{
+					[]byte(`Password`),
+					[]byte(`test`),
 				}
 				for _, b := range needToSee {
 					if !bytes.Contains(parts.plistData, b) {


### PR DESCRIPTION
Fix for Issue #703. I'm not really sure how to add unit tests, but I did perform the following on a test MacBook:

| Current Local Password | CurrentPassword | NewPassword | Result | Notes |
| -------------------------------- | ----------------------- | ------------------- | --------- | -------- |
| test | *empty* | test | Current password not provided | |
| test | test | test | **PasswordChanged** | |
| test | test | *empty* | A firmware password change is already pending. Machine must be rebooted before any additional change requests are accepted. | Oops - good to know |
| test | test | *empty* | **PasswordChanged** | After reboot |
| *empty* | test | test | **PasswordChanged** | If local password is blank, it doesn't matter what you pass in CurrentPassword |

Seems like everything is working.