### PR TITLE
Add Docker workflow. Add ARM build.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,40 @@
+name: Publish Docker image
+on:
+  release:
+    types: [published]
+jobs:
+  push_to_registry:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Set up QEMU for multi-architecture builds
+        uses: docker/setup-qemu-action@c308fdd69d26ed66f4506ebd74b180abe5362145 #v1.1.0
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: all
+
+      - name: Check out this repo
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        with:
+          fetch-depth: 1 # Checkout only latest commit
+
+      - name: Login to Github Packages Container registry with ephemeral token
+        run: docker login ghcr.io --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub with access token
+        run: echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login --username micromdm --password-stdin
+
+      - name: Create builder instance
+        run: docker buildx create --use
+
+      - name: Build and push image
+        run: |
+          docker buildx build \
+           --platform linux/amd64,linux/arm,linux/arm64 \
+           --tag micromdm/micromdm:latest \
+           --tag micromdm/micromdm:${{ github.event.release.tag_name }} \
+           --tag ghcr.io/micromdm/micromdm:latest \
+           --tag ghcr.io/micromdm/micromdm:${{ github.event.release.tag_name }} \
+           --push \
+           .

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,12 @@ FROM golang:latest as builder
 
 WORKDIR /go/src/github.com/micromdm/micromdm/
 
+ARG TARGETARCH
+ARG TARGETOS
+
 ENV CGO_ENABLED=0 \
-	GOARCH=amd64 \
-	GOOS=linux
+	GOARCH=$TARGETARCH \
+	GOOS=$TARGETOS
 
 COPY . .
 


### PR DESCRIPTION
This adds a Github Actions workflow to build a multi-architecture Docker image when new release tags are added. Additionally, support for building ARM images is added.

Here's my [most recent action run](https://github.com/williamtheaker/micromdm/runs/2441081620?check_suite_focus=true) which generated builds for [Github's container registry](https://github.com/users/williamtheaker/packages/container/package/micromdm) and [Docker Hub](https://hub.docker.com/r/williamtheakergusto/micromdm/tags)

This assumes you have [enabled Github Container Registry for the micromdm organization](https://docs.github.com/en/packages/guides/enabling-improved-container-support#enabling-github-container-registry-for-your-organization-account) and added a Github Actions secret named `DOCKER_HUB_ACCESS_TOKEN` with a [Docker Hub token](https://docs.docker.com/docker-hub/access-tokens/#create-an-access-token).