### PR TITLE
Ensuring MicroMDM Logos are Hidden to assistive technologies

### DIFF
--- a/cmd/micromdm/serve.go
+++ b/cmd/micromdm/serve.go
@@ -83,7 +83,7 @@ body {
 <body>
 
 <h1>MicroMDM</h1>
-<svg xmlns="http://www.w3.org/2000/svg" width="204" height="192" viewBox="0 0 51 48">
+<svg xmlns="http://www.w3.org/2000/svg" width="204" height="192" viewBox="0 0 51 48" focusable="false" aria-hidden="true">
   <g fill="none" fill-rule="evenodd">
       <path fill="#366BE0" d="M34 38L0 20 34 0z"/>
       <path fill="#4A9DFF" d="M17 10l34 18-34 20z"/>


### PR DESCRIPTION
Following up on #721 (I was out when I got messages from @williamtheaker), I've added a few extras to the changes proposed there.

While the SVG a11y APIs should ensure that this SVG isn't exposed to assistive technologies, I've added `aria-hidden="true"` to ensure that the content is not exposed to users.

Similarly, while this bug is generally windows-based, and increasingly rare, some OS / browser combinations make all SVG elements focusable via the keyboard by default, so I've added `focusable="false"` to prevent that from happening in these odd corner cases.

Let me know if you have any questions here!