### PR TITLE
Refactor MDM service to return a payload from check-ins

### DIFF
--- a/mdm/checkin.go
+++ b/mdm/checkin.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 )
 
+// Checkin is an MDM Service check-in
 func (svc *MDMService) Checkin(ctx context.Context, event CheckinEvent) ([]byte, error) {
 	// reject user settings at the loginwindow.
 	// https://github.com/micromdm/micromdm/pull/379

--- a/mdm/checkin.go
+++ b/mdm/checkin.go
@@ -10,7 +10,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Checkin is an MDM Service check-in
 func (svc *MDMService) Checkin(ctx context.Context, event CheckinEvent) ([]byte, error) {
 	// reject user settings at the loginwindow.
 	// https://github.com/micromdm/micromdm/pull/379

--- a/mdm/service.go
+++ b/mdm/service.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Service interface {
-	Checkin(ctx context.Context, event CheckinEvent) error
+	Checkin(ctx context.Context, event CheckinEvent) (payload []byte, err error)
 	Acknowledge(ctx context.Context, event AcknowledgeEvent) (payload []byte, err error)
 }
 

--- a/mdm/service.go
+++ b/mdm/service.go
@@ -6,8 +6,15 @@ import (
 	"github.com/micromdm/micromdm/platform/pubsub"
 )
 
+// Service describes the core MDM protocol interactions with clients.
 type Service interface {
+	// Checkin is called for all checkin messages (such as Authenticate
+	// and TokenUpdate). Checkin messages return a response to the
+	// client in payload.
 	Checkin(ctx context.Context, event CheckinEvent) (payload []byte, err error)
+	// Acknowledge is called when a client reports a command result and
+	// fetches the next command. Acknowledge calls return a command in
+	// payload.
 	Acknowledge(ctx context.Context, event AcknowledgeEvent) (payload []byte, err error)
 }
 

--- a/platform/device/udidauth.go
+++ b/platform/device/udidauth.go
@@ -85,7 +85,6 @@ func (mw *udidCertAuthMiddleware) Acknowledge(ctx context.Context, req mdm.Ackno
 	return mw.next.Acknowledge(ctx, req)
 }
 
-// Checkin is an MDM Service check-in
 func (mw *udidCertAuthMiddleware) Checkin(ctx context.Context, req mdm.CheckinEvent) ([]byte, error) {
 	// only validate device enrollments, user enrollments should be separate.
 	if req.Command.EnrollmentID != "" {

--- a/platform/device/udidauth.go
+++ b/platform/device/udidauth.go
@@ -85,6 +85,7 @@ func (mw *udidCertAuthMiddleware) Acknowledge(ctx context.Context, req mdm.Ackno
 	return mw.next.Acknowledge(ctx, req)
 }
 
+// Checkin is an MDM Service check-in
 func (mw *udidCertAuthMiddleware) Checkin(ctx context.Context, req mdm.CheckinEvent) ([]byte, error) {
 	// only validate device enrollments, user enrollments should be separate.
 	if req.Command.EnrollmentID != "" {

--- a/platform/remove/remove.go
+++ b/platform/remove/remove.go
@@ -58,6 +58,7 @@ func (mw removeMiddleware) Acknowledge(ctx context.Context, req mdm.AcknowledgeE
 	return mw.next.Acknowledge(ctx, req)
 }
 
+// Checkin is an MDM Service check-in
 func (mw removeMiddleware) Checkin(ctx context.Context, req mdm.CheckinEvent) ([]byte, error) {
 	return mw.next.Checkin(ctx, req)
 }

--- a/platform/remove/remove.go
+++ b/platform/remove/remove.go
@@ -58,7 +58,6 @@ func (mw removeMiddleware) Acknowledge(ctx context.Context, req mdm.AcknowledgeE
 	return mw.next.Acknowledge(ctx, req)
 }
 
-// Checkin is an MDM Service check-in
 func (mw removeMiddleware) Checkin(ctx context.Context, req mdm.CheckinEvent) ([]byte, error) {
 	return mw.next.Checkin(ctx, req)
 }

--- a/platform/remove/remove.go
+++ b/platform/remove/remove.go
@@ -58,7 +58,7 @@ func (mw removeMiddleware) Acknowledge(ctx context.Context, req mdm.AcknowledgeE
 	return mw.next.Acknowledge(ctx, req)
 }
 
-func (mw removeMiddleware) Checkin(ctx context.Context, req mdm.CheckinEvent) error {
+func (mw removeMiddleware) Checkin(ctx context.Context, req mdm.CheckinEvent) ([]byte, error) {
 	return mw.next.Checkin(ctx, req)
 }
 

--- a/server/devicecert.go
+++ b/server/devicecert.go
@@ -96,7 +96,6 @@ func (mw *verifyCertificateMiddleware) Acknowledge(ctx context.Context, req mdm.
 	return mw.next.Acknowledge(ctx, req)
 }
 
-// Checkin is an MDM Service check-in
 func (mw *verifyCertificateMiddleware) Checkin(ctx context.Context, req mdm.CheckinEvent) ([]byte, error) {
 	devcert, err := mdm.DeviceCertificateFromContext(ctx)
 	if err != nil {

--- a/server/devicecert.go
+++ b/server/devicecert.go
@@ -96,6 +96,7 @@ func (mw *verifyCertificateMiddleware) Acknowledge(ctx context.Context, req mdm.
 	return mw.next.Acknowledge(ctx, req)
 }
 
+// Checkin is an MDM Service check-in
 func (mw *verifyCertificateMiddleware) Checkin(ctx context.Context, req mdm.CheckinEvent) ([]byte, error) {
 	devcert, err := mdm.DeviceCertificateFromContext(ctx)
 	if err != nil {


### PR DESCRIPTION
Currently all of the Checkin messages don't return a response—they all succeed without any return value. However, certain Check-in messages require returning a payload such as `UserAuthenticate`, `GetBootstrapToken`, `DeclarativeManagement`, etc.

This PR adjusts the check-in interface to allow for returning payload data on a Check-in message which gets returned to the client verbatim (much like the `Acknolwedge` interface method already does). Note this PR does not implement any of the above; rather it just makes it possible for them to be implemented.