### PR TITLE
[DRAFT] MDMServiceConfig and Friends

### DIFF
--- a/cmd/micromdm/serve.go
+++ b/cmd/micromdm/serve.go
@@ -105,6 +105,7 @@ func serve(args []string) error {
 		flServerURL              = flagset.String("server-url", env.String("MICROMDM_SERVER_URL", ""), "Public HTTPS url of your server")
 		flAPIKey                 = flagset.String("api-key", env.String("MICROMDM_API_KEY", ""), "API Token for mdmctl command")
 		flTLS                    = flagset.Bool("tls", env.Bool("MICROMDM_TLS", true), "Use https")
+		flTLSCACert              = flagset.String("tls-ca-cert", env.String("MICROMDM_TLS_CA_CERT", ""), "Path to CA certificate (if TLS is self signed)")
 		flTLSCert                = flagset.String("tls-cert", env.String("MICROMDM_TLS_CERT", ""), "Path to TLS certificate")
 		flTLSKey                 = flagset.String("tls-key", env.String("MICROMDM_TLS_KEY", ""), "Path to TLS private key")
 		flHTTPAddr               = flagset.String("http-addr", env.String("MICROMDM_HTTP_ADDR", ":https"), "http(s) listen address of mdm server. defaults to :8080 if tls is false")
@@ -162,6 +163,7 @@ func serve(args []string) error {
 		ServerPublicURL:        strings.TrimRight(*flServerURL, "/"),
 		Depsim:                 *flDepSim,
 		TLSCertPath:            *flTLSCert,
+		TLSCACertPath:          *flTLSCACert,
 		CommandWebhookURL:      *flCommandWebhookURL,
 		NoCmdHistory:           *flNoCmdHistory,
 		UseDynSCEPChallenge:    *flUseDynChallenge,
@@ -248,6 +250,9 @@ func serve(args []string) error {
 	r.Handle("/mdm/enroll", enrollHandlers.EnrollHandler).Methods("GET", "POST")
 	r.Handle("/ota/enroll", enrollHandlers.OTAEnrollHandler)
 	r.Handle("/ota/phase23", enrollHandlers.OTAPhase2Phase3Handler).Methods("POST")
+	r.Handle("/MDMServiceConfig", enrollHandlers.MDMServiceConfigHandler).Methods("GET")
+	r.Handle("/svc/dep_anchor_certs", enrollHandlers.DEPAnchorCertsHandler).Methods("GET")
+	r.Handle("/svc/trust_profile", enrollHandlers.TrustProfileHandler).Methods("GET")
 	r.Handle("/scep", scepHandler)
 	if *flHomePage {
 		r.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/mdm/enroll/service.go
+++ b/mdm/enroll/service.go
@@ -21,22 +21,39 @@ import (
 const (
 	EnrollmentProfileId string = "com.github.micromdm.micromdm.enroll"
 	OTAProfileId        string = "com.github.micromdm.micromdm.ota"
+	TrustProfileId      string = "com.github.micromdm.micromdm.trust"
 )
+
+type mdmServiceConfiguration struct {
+	depEnrollmentUrl      string
+	depAnchorCertsUrl     string
+	trustProfileUrl       string
+	depAnchorCertificates [][]byte
+}
 
 type Service interface {
 	Enroll(ctx context.Context) (profile.Mobileconfig, error)
 	OTAEnroll(ctx context.Context) (profile.Mobileconfig, error)
 	OTAPhase2(ctx context.Context) (profile.Mobileconfig, error)
 	OTAPhase3(ctx context.Context) (profile.Mobileconfig, error)
+	MDMServiceConfig(ctx context.Context) (mdmServiceConfiguration, error)
 }
 
-func NewService(topic TopicProvider, sub pubsub.Subscriber, scepURL, scepChallenge, url, tlsCertPath, scepSubject string, profileDB profile.Store, challengeStore challenge.Store) (Service, error) {
+func NewService(topic TopicProvider, sub pubsub.Subscriber, scepURL, scepChallenge, url, tlsCertPath, scepSubject, tlsCACertPath string, profileDB profile.Store, challengeStore challenge.Store) (Service, error) {
 	var tlsCert []byte
+	var tlsCACert []byte
 	var err error
 
 	if tlsCertPath != "" {
 		tlsCert, err = ioutil.ReadFile(tlsCertPath)
 
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if tlsCACertPath != "" {
+		tlsCACert, err = ioutil.ReadFile(tlsCACertPath)
 		if err != nil {
 			return nil, err
 		}
@@ -67,6 +84,7 @@ func NewService(topic TopicProvider, sub pubsub.Subscriber, scepURL, scepChallen
 		SCEPChallenge:      scepChallenge,
 		SCEPChallengeStore: challengeStore,
 		TLSCert:            tlsCert,
+		TLSCACert:          tlsCACert,
 		ProfileDB:          profileDB,
 		Topic:              pushTopic,
 		topicProvier:       topic,
@@ -113,6 +131,7 @@ type service struct {
 	SCEPChallengeStore challenge.Store
 	SCEPSubject        [][][]string
 	TLSCert            []byte
+	TLSCACert          []byte
 	ProfileDB          profile.Store
 
 	topicProvier TopicProvider
@@ -314,4 +333,44 @@ func (svc *service) MakeOTAPhase2Profile() (Profile, error) {
 // TODO: Not implemented.
 func (svc *service) OTAPhase3(ctx context.Context) (profile.Mobileconfig, error) {
 	return profile.Mobileconfig{}, nil
+}
+
+func (svc *service) MakeTrustProfile() (Profile, error) {
+	profile := NewProfile()
+	profile.PayloadIdentifier = TrustProfileId
+	profile.PayloadOrganization = "MicroMDM"
+	profile.PayloadDisplayName = "Trust Profile"
+	profile.PayloadDescription = "Trusts the MicroMDM Server (If not publicly signed)"
+	profile.PayloadScope = "System"
+
+	trustPayload := NewPayload("com.apple.security.root")
+	trustPayload.PayloadDescription = "Trusts the Certificate Authority that issued the MDM servers SSL certificate"
+	trustPayload.PayloadDisplayName = "CA Trust"
+	trustPayload.PayloadIdentifier = TrustProfileId + ".root"
+	trustPayload.PayloadOrganization = "MicroMDM"
+	//trustPayload.PayloadContent = ""
+	trustPayload.PayloadScope = "System"
+
+	profile.PayloadContent = append(profile.PayloadContent, *trustPayload)
+
+	return *profile, nil
+}
+
+func (svc *service) MDMServiceConfig(ctx context.Context) (mdmServiceConfiguration, error) {
+	anchorCerts := make([][]byte, 0, 1)
+
+	// As per the documentation, it is valid for MDMServiceConfig to return a zero length array for anchor certs
+	// if the MDM endpoint would be trusted by the device out of the box.
+	if len(svc.TLSCACert) > 0 {
+		anchorCerts = append(anchorCerts, svc.TLSCACert)
+	}
+
+	serviceConfig := mdmServiceConfiguration{
+		depEnrollmentUrl:      svc.URL + "/mdm/enroll",
+		depAnchorCertificates: anchorCerts,
+		depAnchorCertsUrl:     svc.URL + "/svc/dep_anchor_certs",
+		trustProfileUrl:       svc.URL + "/svc/trust_profile",
+	}
+
+	return serviceConfig, nil
 }

--- a/mdm/enroll/transport_http.go
+++ b/mdm/enroll/transport_http.go
@@ -3,6 +3,7 @@ package enroll
 import (
 	"context"
 	"errors"
+	"github.com/micromdm/micromdm/pkg/httputil"
 	"io/ioutil"
 	"net/http"
 
@@ -20,6 +21,10 @@ type HTTPHandlers struct {
 	// In Apple's Over-the-Air design Phases 2 and 3 happen over the same URL.
 	// The differentiator is which certificate signed the CMS POST body.
 	OTAPhase2Phase3Handler http.Handler
+
+	MDMServiceConfigHandler http.Handler
+	DEPAnchorCertsHandler   http.Handler
+	TrustProfileHandler     http.Handler
 }
 
 func MakeHTTPHandlers(ctx context.Context, endpoints Endpoints, opts ...httptransport.ServerOption) HTTPHandlers {
@@ -39,6 +44,24 @@ func MakeHTTPHandlers(ctx context.Context, endpoints Endpoints, opts ...httptran
 		OTAPhase2Phase3Handler: httptransport.NewServer(
 			endpoints.OTAPhase2Phase3Endpoint,
 			decodeOTAPhase2Phase3Request,
+			encodeMobileconfigResponse,
+			opts...,
+		),
+		MDMServiceConfigHandler: httptransport.NewServer(
+			endpoints.MDMServiceConfigEndpoint,
+			decodeEmptyRequest,
+			httputil.EncodeJSONResponse,
+			opts...,
+		),
+		DEPAnchorCertsHandler: httptransport.NewServer(
+			endpoints.DEPAnchorCertsEndpoint,
+			decodeEmptyRequest,
+			httputil.EncodeJSONResponse,
+			opts...,
+		),
+		TrustProfileHandler: httptransport.NewServer(
+			endpoints.TrustProfileEndpoint,
+			decodeEmptyRequest,
 			encodeMobileconfigResponse,
 			opts...,
 		),

--- a/server/server.go
+++ b/server/server.go
@@ -49,6 +49,7 @@ type Server struct {
 	SCEPChallenge          string
 	SCEPClientValidity     int
 	TLSCertPath            string
+	TLSCACertPath          string
 	SCEPDepot              depot.Depot
 	UseDynSCEPChallenge    bool
 	GenDynSCEPChallenge    bool
@@ -266,6 +267,7 @@ func (c *Server) setupEnrollmentService() error {
 		c.ServerPublicURL,
 		c.TLSCertPath,
 		SCEPCertificateSubject,
+		c.TLSCACertPath,
 		c.ProfileDB,
 		chalStore,
 	)


### PR DESCRIPTION
Add endpoints for MDMServiceConfig and its dependencies: dep anchor certs endpoint and trust endpoint
Added a CLI flag -tls-ca-cert for specifying a Certificate Authority to trust, if the device must trust a CA in order to enroll with the MDM (self-signed or privately issued certificate)
Incomplete implementation of trust profile endpoint
Incomplete implementation of dep anchor certificate endpoint.