### PR TITLE
Golang updates

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build, test & format
     strategy:
       matrix:
-        go-version: [1.15.x, 1.16.x]
+        go-version: [1.16.x, 1.17.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest as builder
+FROM golang:1.17 as builder
 
 WORKDIR /go/src/github.com/micromdm/micromdm/
 

--- a/cmd/mdmctl/sign.go
+++ b/cmd/mdmctl/sign.go
@@ -1,3 +1,4 @@
+//go:build !darwin
 // +build !darwin
 
 package main

--- a/go.mod
+++ b/go.mod
@@ -3,38 +3,45 @@ module github.com/micromdm/micromdm
 require (
 	github.com/RobotsAndPencils/buford v0.12.0
 	github.com/boltdb/bolt v1.3.1
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/felixge/httpsnoop v1.0.2 // indirect
 	github.com/garyburd/go-oauth v0.0.0-20180319155456-bca2e7f09a17
 	github.com/go-kit/kit v0.7.0
-	github.com/go-sql-driver/mysql v1.4.0 // indirect
-	github.com/go-stack/stack v1.7.0 // indirect
 	github.com/google/uuid v1.1.1
-	github.com/gorilla/context v1.1.1 // indirect
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.6.2
 	github.com/groob/finalizer v0.0.0-20170707115354-4c2ed49aabda
 	github.com/groob/plist v0.0.0-20180203051248-dd56909aee38
 	github.com/jmoiron/sqlx v0.0.0-20180614180643-0dae4fefe7c0
 	github.com/kolide/kit v0.0.0-20180912215818-0c28f72eb2b0
-	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
-	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
 	github.com/lib/pq v1.0.0
-	github.com/mattn/go-sqlite3 v1.9.0 // indirect
 	github.com/micromdm/go4 v0.0.0-20210104222236-8a0936d9e451
 	github.com/micromdm/scep/v2 v2.1.0
 	github.com/pkg/errors v0.8.0
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/pressly/goose v2.3.0+incompatible
-	github.com/stretchr/testify v1.2.2 // indirect
-	github.com/ziutek/mymysql v1.5.4 // indirect
 	go.mozilla.org/pkcs7 v0.0.0-20210826202110-33d05740a352
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/net v0.0.0-20201021035429-f5854403a974
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	google.golang.org/appengine v1.2.0 // indirect
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/Masterminds/squirrel.v1 v1.0.0-20170825200431-a6b93000bd21
 )
 
-go 1.13
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/felixge/httpsnoop v1.0.2 // indirect
+	github.com/go-logfmt/logfmt v0.3.0 // indirect
+	github.com/go-sql-driver/mysql v1.4.0 // indirect
+	github.com/go-stack/stack v1.7.0 // indirect
+	github.com/gorilla/context v1.1.1 // indirect
+	github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 // indirect
+	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
+	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
+	github.com/mattn/go-sqlite3 v1.9.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.2.2 // indirect
+	github.com/ziutek/mymysql v1.5.4 // indirect
+	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f // indirect
+	golang.org/x/text v0.3.3 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	google.golang.org/appengine v1.2.0 // indirect
+)
+
+go 1.17

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package tools

--- a/platform/apns/pg/pg_test.go
+++ b/platform/apns/pg/pg_test.go
@@ -1,3 +1,4 @@
+//go:build pg
 // +build pg
 
 package pg

--- a/platform/device/pg/pg_test.go
+++ b/platform/device/pg/pg_test.go
@@ -1,3 +1,4 @@
+//go:build pg
 // +build pg
 
 package pg


### PR DESCRIPTION
This PR does:

- update GitHub action to use 1.16/1.17
- pins golang version in the Dockerfile
- adds go mod tidy and module updates to go.mod
- bump go version to 1.17