### PR TITLE
Show mdmctl config switch usage if no server -name passed

### DIFF
--- a/cmd/mdmctl/config.go
+++ b/cmd/mdmctl/config.go
@@ -274,6 +274,9 @@ func switchServerConfig(name string) error {
 	if err != nil {
 		return err
 	}
+	if name == "" {
+		return errors.New("bad input: name can't be empty.")
+	}
 	if _, ok := clientCfg.Servers[name]; !ok {
 		return fmt.Errorf("no server named \"%s\" found", name)
 	}

--- a/cmd/mdmctl/config.go
+++ b/cmd/mdmctl/config.go
@@ -178,6 +178,11 @@ func switchCmd(args []string) error {
 	if err := flagset.Parse(args); err != nil {
 		return err
 	}
+	
+	if flagset.NFlag() == 0 {
+		flagset.Usage()
+		os.Exit(1)
+	}
 
 	return switchServerConfig(*flName)
 }

--- a/cmd/mdmctl/config.go
+++ b/cmd/mdmctl/config.go
@@ -178,7 +178,7 @@ func switchCmd(args []string) error {
 	if err := flagset.Parse(args); err != nil {
 		return err
 	}
-	
+
 	if flagset.NFlag() == 0 {
 		flagset.Usage()
 		os.Exit(1)


### PR DESCRIPTION
`mdmctl config switch` currently doesn't provide any hint that a `-name` flag should be passed:

```
% ./mdmctl config switch
no server named "" found
% ./mdmctl config switch example
no server named "" found
```

After this patch:
```
% build/darwin/mdmctl config switch
USAGE
  mdmctl config switch [flags]

FLAGS
  -name   name of the server to switch to
```