### PR TITLE
Fix to 502 Bad Gateway error while communicating with Apple Servers

### DIFF
--- a/pkg/crypto/mdmcertutil/certutil.go
+++ b/pkg/crypto/mdmcertutil/certutil.go
@@ -73,7 +73,7 @@ func (p *PushCertificateRequest) Encode() ([]byte, error) {
 
 const (
 	wwdrIntermediaryURL = "https://www.apple.com/certificateauthority/AppleWWDRCAG3.cer"
-	appleRootCAURL      = "http://www.apple.com/appleca/AppleIncRootCertificate.cer"
+	appleRootCAURL      = "https://www.apple.com/appleca/AppleIncRootCertificate.cer"
 )
 
 // CreatePushCertificateRequest creates a request structure required by identity.apple.com.


### PR DESCRIPTION
Hi! Today I was renewing my certificates and I found an error while signing the push certificate:

```
$ ./mdmctl mdmcert vendor -sign -cert=./mdm-certificates/mdm.cer -password=MyAwesomePassword

signing push certificate request with vendor private key: load root certificate from http://www.apple.com/appleca/AppleIncRootCertificate.cer: got 502 Bad Gateway when trying to http.Get http://www.apple.com/appleca/AppleIncRootCertificate.cer
```

I tried to get the certfile using wget using the same url and it throws the same error. The only way to retrieve that file was to communicate using https.

I know this pull request is trivial (I only added an 's' to the url) but I was able to create and sign my push certificate after this change.