### PR TITLE
Fix RotateFileVaultKey panics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.6.2
 	github.com/groob/finalizer v0.0.0-20170707115354-4c2ed49aabda
-	github.com/groob/plist v0.0.0-20180203051248-dd56909aee38
+	github.com/groob/plist v0.0.0-20220217120414-63fa881b19a5
 	github.com/jmoiron/sqlx v0.0.0-20180614180643-0dae4fefe7c0
 	github.com/kolide/kit v0.0.0-20180912215818-0c28f72eb2b0
 	github.com/lib/pq v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/groob/finalizer v0.0.0-20170707115354-4c2ed49aabda h1:5ikpG9mYCMFiZX0
 github.com/groob/finalizer v0.0.0-20170707115354-4c2ed49aabda/go.mod h1:MyndkAZd5rUMdNogn35MWXBX1UiBigrU8eTj8DoAC2c=
 github.com/groob/plist v0.0.0-20180203051248-dd56909aee38 h1:afbUddvIjPRC7XHHgeSTRfzZtIxEsSl4VCxumLBGDJU=
 github.com/groob/plist v0.0.0-20180203051248-dd56909aee38/go.mod h1:qg2Nek0ND/hIr+nY8H1oVqEW2cLzVVNaAQ0QexOyjyc=
+github.com/groob/plist v0.0.0-20220217120414-63fa881b19a5 h1:saaSiB25B1wgaxrshQhurfPKUGJ4It3OxNJUy0rdOjU=
+github.com/groob/plist v0.0.0-20220217120414-63fa881b19a5/go.mod h1:itkABA+w2cw7x5nYUS/pLRef6ludkZKOigbROmCTaFw=
 github.com/jmoiron/sqlx v0.0.0-20180614180643-0dae4fefe7c0 h1:5B0uxl2lzNRVkJVg+uGHxWtRt4C0Wjc6kJKo5XYx8xE=
 github.com/jmoiron/sqlx v0.0.0-20180614180643-0dae4fefe7c0/go.mod h1:IiEW3SEiiErVyFdH8NTuWjSifiEQKUoyK3LNqr2kCHU=
 github.com/kolide/kit v0.0.0-20180912215818-0c28f72eb2b0 h1:8UB0NJBoB/lN2O9zG9+U2klyYE0UhvN2Zrn7HBjhwNY=

--- a/mdm/mdm/mdm_command_test.go
+++ b/mdm/mdm/mdm_command_test.go
@@ -126,6 +126,17 @@ func TestMarshalCommand(t *testing.T) {
 				},
 			},
 		},
+		{
+			Command: Command{
+				RequestType: "RotateFileVaultKey",
+				RotateFileVaultKey: &RotateFileVaultKey{
+					KeyType: "personal",
+					FileVaultUnlock: FileVaultUnlock{
+						Password: "password",
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.Command.RequestType+"_json", func(t *testing.T) {


### PR DESCRIPTION
There's currently an issue as noted on the MacAdmins slack with the RotateFileVaultKey command panicking in certain cases due to a edge case in the plist library.

This PR adds a test for the panic case and updates the plist library to [the fixed version](https://github.com/groob/plist/pull/36).