### PR TITLE
mdmctl: don't send a request body for GET requests

### DIFF
--- a/pkg/httputil/httputil.go
+++ b/pkg/httputil/httputil.go
@@ -97,6 +97,10 @@ func JSONErrorDecoder(r *http.Response) error {
 	return errors.New(w.Error)
 }
 
+func EncodeEmptyRequest(c context.Context, r *http.Request, request interface{}) error {
+	return nil
+}
+
 func EncodeRequestWithToken(token string, next httptransport.EncodeRequestFunc) httptransport.EncodeRequestFunc {
 	return func(ctx context.Context, r *http.Request, request interface{}) error {
 		r.SetBasicAuth("micromdm", token)

--- a/platform/config/client.go
+++ b/platform/config/client.go
@@ -42,7 +42,7 @@ func NewHTTPClient(instance, token string, logger log.Logger, opts ...httptransp
 		getDEPTokensEndpoint = httptransport.NewClient(
 			"GET",
 			httputil.CopyURL(u, "/v1/dep-tokens"),
-			httputil.EncodeRequestWithToken(token, httptransport.EncodeJSONRequest),
+			httputil.EncodeRequestWithToken(token, httputil.EncodeEmptyRequest),
 			decodeGetDEPTokensResponse,
 			opts...,
 		).Endpoint()

--- a/platform/dep/client.go
+++ b/platform/dep/client.go
@@ -65,7 +65,7 @@ func NewHTTPClient(instance, token string, logger log.Logger, opts ...httptransp
 		getAccountInfoEndpoint = httptransport.NewClient(
 			"GET",
 			httputil.CopyURL(u, "/v1/dep/account"),
-			httputil.EncodeRequestWithToken(token, httptransport.EncodeJSONRequest),
+			httputil.EncodeRequestWithToken(token, httputil.EncodeEmptyRequest),
 			decodeGetAccountInfoResponse,
 			opts...,
 		).Endpoint()

--- a/platform/dep/get_account_info.go
+++ b/platform/dep/get_account_info.go
@@ -18,7 +18,6 @@ func (svc *DEPService) GetAccountInfo(ctx context.Context) (*dep.Account, error)
 	return svc.client.Account()
 }
 
-type getAccountInfoRequest struct{}
 type getAccountInfoResponse struct {
 	*dep.Account
 	Err error `json:"err,omitempty"`
@@ -44,8 +43,7 @@ func MakeGetAccountInfoEndpoint(svc Service) endpoint.Endpoint {
 }
 
 func (e Endpoints) GetAccountInfo(ctx context.Context) (*dep.Account, error) {
-	request := getAccountInfoRequest{}
-	response, err := e.GetAccountInfoEndpoint(ctx, request)
+	response, err := e.GetAccountInfoEndpoint(ctx, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/platform/dep/sync/client.go
+++ b/platform/dep/sync/client.go
@@ -43,7 +43,7 @@ func NewHTTPClient(instance, token string, logger log.Logger, opts ...httptransp
 		getAutoAssignersEndpoint = httptransport.NewClient(
 			"GET",
 			httputil.CopyURL(u, "/v1/dep/autoassigners"),
-			httputil.EncodeRequestWithToken(token, httptransport.EncodeJSONRequest),
+			httputil.EncodeRequestWithToken(token, httputil.EncodeEmptyRequest),
 			decodeGetAutoAssignersResponse,
 			opts...,
 		).Endpoint()


### PR DESCRIPTION
Per recent conversations on MacAdmins slack, mdmctl sends a request body of `null` or `{}` for:

* `mdmctl get dep-account`
* `mdmctl get dep-autoassigners`
* `mdmctl get dep-tokens`

This happens because `nil` or an empty struct is passed to [EncodeJSONRequest](https://github.com/go-kit/kit/blob/master/transport/http/client.go#L175).

This is problematic for HTTP proxies/load balancers that don't like GET requests with bodies. There's also no reason to send these empty bodies as they're not parsed by the server anyways.

This commit adds a noop `EncodeEmptyRequest` helper and uses it for those `GET` endpoints. It also removes an unused empty struct for the get-account endpoint to match the other two.

I've tested this against MicroMDM v1.9.0. 