### PR TITLE
Add max_user_deferrals

### DIFF
--- a/tools/api/commands/schedule_os_update
+++ b/tools/api/commands/schedule_os_update
@@ -6,11 +6,13 @@ jq -n \
   --arg udid "$1" \
   --arg product_key "$2" \
   --arg install_action "$3" \
+  --arg max_user_deferrals $4 \
   '.udid = $udid 
   |.request_type = $request_type
   |.updates = [
       .product_key = $product_key
       |.install_action = $install_action
+      |.max_user_deferrals = $max_user_deferrals
       ]
   '|\
   curl $CURL_OPTS -K <(cat <<< "-u micromdm:$API_TOKEN") "$SERVER_URL/$endpoint" -d@-


### PR DESCRIPTION
The maximum number of times the system allows the user to postpone an update before it’s installed. The system prompts the user once a day.
This key is only supported when InstallAction is InstallLater and only supported for minor OS updates (for example, macOS 12.x to 12.y).