### PR TITLE
Change PushCertificateRequest file extension to txt

### DIFF
--- a/cmd/mdmctl/mdmcert.go
+++ b/cmd/mdmctl/mdmcert.go
@@ -53,7 +53,7 @@ Once you created the push CSR, you mush sign the push CSR with the MDM Vendor Ce
 
     mdmctl mdmcert vendor -sign -cert=./mdm-certificates/mdm.cer -password=secret
 
-Once generated, upload the PushCertificateRequest.plist file to https://identity.apple.com to obtain your MDM Push Certificate.
+Once generated, upload the PushCertificateRequest.txt file to https://identity.apple.com to obtain your MDM Push Certificate.
 Use the push private key and the push cert you got from identity.apple.com in your MDM server.
 
 Commands:
@@ -97,7 +97,7 @@ const (
 	pushCertificatePrivateKeyFilename = "PushCertificatePrivateKey.key"
 	vendorPKeyFilename                = "VendorPrivateKey.key"
 	vendorCSRFilename                 = "VendorCertificateRequest.csr"
-	pushRequestFilename               = "PushCertificateRequest.plist"
+	pushRequestFilename               = "PushCertificateRequest.txt"
 	mdmcertdir                        = "mdm-certificates"
 )
 

--- a/docs/user-guide/quickstart.md
+++ b/docs/user-guide/quickstart.md
@@ -129,9 +129,9 @@ Now sign the push certificate request with the vendor certificate. This step use
 mdmctl mdmcert vendor -sign -cert=./mdm-certificates/mdm.cer -password=secret
 ```
 
-You should now have a `mdm-certificates/PushCertificateRequest.plist` file. 
+You should now have a `mdm-certificates/PushCertificateRequest.txt` file.
 
-Sign in to [identity.apple.com](https://identity.apple.com) and upload the `PushCertificateRequest.plist` file to get the APNS certificate. The site offers a notes field, it's a good idea to use it to mark which server you're obtaining a certificate for, as you will come back for renewals. 
+Sign in to [identity.apple.com](https://identity.apple.com) and upload the `PushCertificateRequest.txt` file to get the APNS certificate. The site offers a notes field, it's a good idea to use it to mark which server you're obtaining a certificate for, as you will come back for renewals.
 
 If you're getting certificates for multiple environments (staging, production) or running multiple in house MDM instances, you MUST sign a separate push request for each one. Using the same vendor certificate is okay, but using the same push certificate is not. 
 


### PR DESCRIPTION
Since the Apple Push Certificates Portal lately only allows `.csr`, `.txt` or `.rtf` files, the `.plist` file cannot be uploaded to the Portal (see Screenshot). 

By changing it to .txt it works like expected.

<img width="627" alt="Screenshot 2022-06-27 at 12 34 33" src="https://user-images.githubusercontent.com/792046/175924147-b3a519a9-145b-4dfd-87f4-0cd455bdb0db.png">

