### PR TITLE
Enable Dependabot version updating.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Don't change this despite the path being .github/workflows
+    schedule:
+      # Check for updates to GitHub Actions on the first day of the month
+      interval: "monthly"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      # Check for updates to Go modules on the first day of the month
+      interval: "monthly"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,26 +8,26 @@ on:
 
 jobs:
   build-test:
-    name: Build, test & format
+    name: Build, test, and format
     strategy:
       matrix:
         go-version: [1.16.x, 1.17.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
 
-    - name: setup go
-      uses: actions/setup-go@v2
+    - name: Setup Go
+      uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
       with:
         go-version: ${{ matrix.go-version }}
+
+    - name: Format
+      if: matrix.platform == 'ubuntu-latest'
+      run: if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then exit 1; fi
 
     - name: Build
       run: go build -v ./...
 
     - name: Test
       run: go test -v ./...
-
-    - name: Format
-      if: matrix.platform == 'ubuntu-latest'
-      run: if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then exit 1; fi

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,15 +9,13 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Set up QEMU for multi-architecture builds
-        uses: docker/setup-qemu-action@c308fdd69d26ed66f4506ebd74b180abe5362145 #v1.1.0
+        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 #v2.1.0
         with:
           image: tonistiigi/binfmt:latest
           platforms: all
 
       - name: Check out this repo
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
-        with:
-          fetch-depth: 1 # Checkout only latest commit
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
 
       - name: Login to Github Packages Container registry with ephemeral token
         run: docker login ghcr.io --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Someone (me) pinned old versions of Github Actions, which is causing deprecation warnings in your actions: `The save-state command is deprecated and will be disabled soon. Please upgrade to using Environment Files.` & `Node.js 12 actions are deprecated.`. This PR enables Dependabot, which will checking for updates and open PRs to bump the pinned version for Github Actions and Go modules.

I've left the checkout action in the Docker worklow one version behind, so you can see an example Dependabot PR upon merging this branch.

I also moved `gofmt` to earlier in the CI run, on the assumption that you don't want to waste minutes building commits that haven't been linted.