### PR TITLE
Add raw command and clear device queue endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [Unreleased](https://github.com/micromdm/micromdm/compare/v1.10.1...main)
 
 - Add SoftwareUpdateSettings to Settings command (#771, #856)
+- Ensure errors are logged on the checkin and connect endpoints (#871)
+- Add support for raw plist commands (#864)
 
 ## [v1.10.1](https://github.com/micromdm/micromdm/compare/v1.10.0...v1.10.1) January 24, 2023
 

--- a/platform/command/clear.go
+++ b/platform/command/clear.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (svc *CommandService) ClearQueue(ctx context.Context, udid string) error {
-	if err := svc.queue.Clear(context.TODO(), mdm.CheckinEvent{Command: mdm.CheckinCommand{UDID: udid}}); err != nil {
+	if err := svc.queue.Clear(ctx, mdm.CheckinEvent{Command: mdm.CheckinCommand{UDID: udid}}); err != nil {
 		return errors.Wrap(err, "clearing command queue")
 	}
 	return nil

--- a/platform/command/clear.go
+++ b/platform/command/clear.go
@@ -1,0 +1,47 @@
+package command
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/go-kit/kit/endpoint"
+	"github.com/gorilla/mux"
+	"github.com/micromdm/micromdm/mdm"
+	"github.com/pkg/errors"
+)
+
+func (svc *CommandService) ClearQueue(ctx context.Context, udid string) error {
+	if err := svc.queue.Clear(context.TODO(), mdm.CheckinEvent{Command: mdm.CheckinCommand{UDID: udid}}); err != nil {
+		return errors.Wrap(err, "clearing command queue")
+	}
+	return nil
+}
+
+type clearRequest struct {
+	UDID string
+}
+
+type clearResponse struct {
+	Err error `json:"error,omitempty"`
+}
+
+func (r clearResponse) Failed() error   { return r.Err }
+func (r clearResponse) StatusCode() int { return http.StatusOK }
+
+func decodeClearRequest(ctx context.Context, r *http.Request) (interface{}, error) {
+	return clearRequest{UDID: mux.Vars(r)["udid"]}, nil
+}
+
+// MakeClearQueueEndpoint creates an endpoint which clears device queues.
+func MakeClearQueueEndpoint(svc Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(clearRequest)
+		if req.UDID == "" {
+			return clearResponse{Err: errEmptyRequest}, nil
+		}
+		if err := svc.ClearQueue(ctx, req.UDID); err != nil {
+			return clearResponse{Err: err}, nil
+		}
+		return clearResponse{}, nil
+	}
+}

--- a/platform/command/event.go
+++ b/platform/command/event.go
@@ -97,10 +97,6 @@ func UnmarshalRawEvent(data []byte, e *RawEvent) error {
 	if err := proto.Unmarshal(data, &pb); err != nil {
 		return errors.Wrap(err, "unmarshal pb Event")
 	}
-	var payload mdm.CommandPayload
-	if err := mdm.UnmarshalCommandPayload(pb.PayloadBytes, &payload); err != nil {
-		return err
-	}
 	e.CommandUUID = pb.Id
 	e.Time = time.Unix(0, pb.Time).UTC()
 	e.DeviceUDID = pb.DeviceUdid

--- a/platform/command/event.go
+++ b/platform/command/event.go
@@ -61,3 +61,49 @@ func UnmarshalEvent(data []byte, e *Event) error {
 	e.Payload = &payload
 	return nil
 }
+
+type RawEvent struct {
+	CommandUUID string
+	Time        time.Time
+	DeviceUDID  string
+	Payload     []byte
+}
+
+// NewRawEvent returns a RawEvent with the current time.
+func NewRawEvent(cmd *RawCommand) *RawEvent {
+	event := RawEvent{
+		CommandUUID: cmd.CommandUUID,
+		Time:        time.Now().UTC(),
+		DeviceUDID:  cmd.UDID,
+		Payload:     cmd.Raw,
+	}
+	return &event
+}
+
+// MarshalRawEvent serializes a RawEvent to a protocol buffer wire format.
+func MarshalRawEvent(e *RawEvent) ([]byte, error) {
+	return proto.Marshal(&commandproto.Event{
+		Id:           e.CommandUUID, // Id isn't used anywhere, so it's repurposed for CommandUUID
+		Time:         e.Time.UnixNano(),
+		DeviceUdid:   e.DeviceUDID,
+		PayloadBytes: e.Payload,
+	})
+}
+
+// UnmarshalRawEvent parses a protocol buffer representation of data into
+// the RawEvent.
+func UnmarshalRawEvent(data []byte, e *RawEvent) error {
+	var pb commandproto.Event
+	if err := proto.Unmarshal(data, &pb); err != nil {
+		return errors.Wrap(err, "unmarshal pb Event")
+	}
+	var payload mdm.CommandPayload
+	if err := mdm.UnmarshalCommandPayload(pb.PayloadBytes, &payload); err != nil {
+		return err
+	}
+	e.CommandUUID = pb.Id
+	e.Time = time.Unix(0, pb.Time).UTC()
+	e.DeviceUDID = pb.DeviceUdid
+	e.Payload = pb.PayloadBytes
+	return nil
+}

--- a/platform/command/event_test.go
+++ b/platform/command/event_test.go
@@ -1,0 +1,49 @@
+package command_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/micromdm/micromdm/platform/command"
+)
+
+const testRawCmd = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Command</key>
+    <dict>
+        <key>ManagedOnly</key>
+        <true/>
+        <key>RequestType</key>
+        <string>ProfileList</string>
+    </dict>
+    <key>CommandUUID</key>
+    <string>0001_ProfileList</string>
+</dict>
+</plist>`
+
+func TestRawEvent(t *testing.T) {
+	cmd := &command.RawCommand{
+		UDID:        "1234",
+		CommandUUID: "0001_ProfileList",
+		Raw:         []byte(testRawCmd),
+	}
+	cmd.Command.RequestType = "ProfileList"
+
+	ev := command.NewRawEvent(cmd)
+
+	buf, err := command.MarshalRawEvent(ev)
+	if err != nil {
+		t.Fatalf("could not marshal event: %v", err)
+	}
+
+	ev2 := new(command.RawEvent)
+	if err = command.UnmarshalRawEvent(buf, ev2); err != nil {
+		t.Fatalf("could not unmarshal event: %v", err)
+	}
+
+	if !reflect.DeepEqual(ev, ev2) {
+		t.Error("expected events to be equal")
+	}
+}

--- a/platform/command/new_command.go
+++ b/platform/command/new_command.go
@@ -1,9 +1,12 @@
 package command
 
 import (
+	"bytes"
 	"net/http"
 
 	"github.com/go-kit/kit/endpoint"
+	"github.com/gorilla/mux"
+	"github.com/groob/plist"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
@@ -14,6 +17,9 @@ import (
 const (
 	// CommandTopic is a PubSub topic that events are published to.
 	CommandTopic = "mdm.Command"
+
+	// RawCommandTopic is a PubSub topic that events are published to.
+	RawCommandTopic = "mdm.RawCommand"
 )
 
 func (svc *CommandService) NewCommand(ctx context.Context, request *mdm.CommandRequest) (*mdm.CommandPayload, error) {
@@ -33,6 +39,21 @@ func (svc *CommandService) NewCommand(ctx context.Context, request *mdm.CommandR
 		return nil, errors.Wrapf(err, "publish mdm command on topic: %s", CommandTopic)
 	}
 	return payload, nil
+}
+
+func (svc *CommandService) NewRawCommand(ctx context.Context, cmd *RawCommand) error {
+	if cmd == nil {
+		return errors.New("empty RawCommand")
+	}
+	event := NewRawEvent(cmd)
+	msg, err := MarshalRawEvent(event)
+	if err != nil {
+		return errors.Wrap(err, "marshalling raw mdm command event")
+	}
+	if err := svc.publisher.Publish(context.TODO(), RawCommandTopic, msg); err != nil {
+		return errors.Wrapf(err, "publish raw mdm command on topic: %s", RawCommandTopic)
+	}
+	return nil
 }
 
 type newCommandRequest struct {
@@ -67,5 +88,62 @@ func MakeNewCommandEndpoint(svc Service) endpoint.Endpoint {
 			return newCommandResponse{Err: err}, nil
 		}
 		return newCommandResponse{Payload: payload}, nil
+	}
+}
+
+type RawCommand struct {
+	UDID        string `json:"udid" plist:"-"`
+	CommandUUID string `json:"command_uuid"`
+	Command     struct {
+		RequestType string `json:"request_type"`
+	} `json:"command"`
+	Raw []byte `plist:"-"`
+}
+
+type newRawCommandRequest struct {
+	RawCommand
+}
+
+type newRawCommandResponse struct {
+	Payload *RawCommand `json:"payload,omitempty"`
+	Err     error       `json:"error,omitempty"`
+}
+
+func (r newRawCommandResponse) Failed() error   { return r.Err }
+func (r newRawCommandResponse) StatusCode() int { return http.StatusCreated }
+
+func decodeNewRawCommandRequest(ctx context.Context, r *http.Request) (interface{}, error) {
+	udid, ok := mux.Vars(r)["udid"]
+	if !ok {
+		return nil, errors.New("empty udid")
+	}
+
+	buf := new(bytes.Buffer)
+	if _, err := buf.ReadFrom(r.Body); err != nil {
+		return nil, err
+	}
+
+	// verify body is valid plist and parse CommandUUID and RequestType
+	var req newRawCommandRequest
+	if err := plist.NewXMLDecoder(buf).Decode(&req); err != nil {
+		return nil, err
+	}
+
+	req.UDID = udid
+	req.Raw = buf.Bytes()
+	return req, nil
+}
+
+// MakeNewRawCommandEndpoint creates an endpoint which creates new raw MDM Commands.
+func MakeNewRawCommandEndpoint(svc Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(newRawCommandRequest)
+		if req.CommandUUID == "" || req.Command.RequestType == "" {
+			return newRawCommandResponse{Err: errEmptyRequest}, nil
+		}
+		if err := svc.NewRawCommand(ctx, &req.RawCommand); err != nil {
+			return newRawCommandResponse{Err: err}, nil
+		}
+		return newRawCommandResponse{Payload: &req.RawCommand}, nil
 	}
 }

--- a/platform/command/new_command.go
+++ b/platform/command/new_command.go
@@ -136,12 +136,17 @@ func decodeNewRawCommandRequest(ctx context.Context, r *http.Request) (interface
 	return req, nil
 }
 
+var errMalformedRequest = errors.New("request is malformed")
+
 // MakeNewRawCommandEndpoint creates an endpoint which creates new raw MDM Commands.
 func MakeNewRawCommandEndpoint(svc Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(newRawCommandRequest)
-		if req.CommandUUID == "" || req.Command.RequestType == "" {
+		if req.UDID == "" {
 			return newRawCommandResponse{Err: errEmptyRequest}, nil
+		}
+		if req.CommandUUID == "" || req.Command.RequestType == "" {
+			return newRawCommandResponse{Err: errMalformedRequest}, nil
 		}
 		if err := svc.NewRawCommand(ctx, &req.RawCommand); err != nil {
 			return newRawCommandResponse{Err: err}, nil

--- a/platform/command/new_command.go
+++ b/platform/command/new_command.go
@@ -97,7 +97,7 @@ type RawCommand struct {
 	Command     struct {
 		RequestType string `json:"request_type"`
 	} `json:"command"`
-	Raw []byte `plist:"-"`
+	Raw []byte `plist:"-" json:"payload"`
 }
 
 type newRawCommandRequest struct {

--- a/platform/command/server.go
+++ b/platform/command/server.go
@@ -8,21 +8,30 @@ import (
 )
 
 type Endpoints struct {
-	NewCommandEndpoint endpoint.Endpoint
+	NewCommandEndpoint    endpoint.Endpoint
+	NewRawCommandEndpoint endpoint.Endpoint
 }
 
 func MakeServerEndpoints(s Service, outer endpoint.Middleware, others ...endpoint.Middleware) Endpoints {
 	return Endpoints{
-		NewCommandEndpoint: endpoint.Chain(outer, others...)(MakeNewCommandEndpoint(s)),
+		NewCommandEndpoint:    endpoint.Chain(outer, others...)(MakeNewCommandEndpoint(s)),
+		NewRawCommandEndpoint: endpoint.Chain(outer, others...)(MakeNewRawCommandEndpoint(s)),
 	}
 }
 
 func RegisterHTTPHandlers(r *mux.Router, e Endpoints, options ...httptransport.ServerOption) {
 	// POST     /v1/commands		Add new MDM Command to device queue.
-
 	r.Methods("POST").Path("/v1/commands").Handler(httptransport.NewServer(
 		e.NewCommandEndpoint,
 		decodeNewCommandRequest,
+		httputil.EncodeJSONResponse,
+		options...,
+	))
+
+	// POST     /v1/commands/udid		Add new MDM Command with raw plist to device queue.
+	r.Methods("POST").Path("/v1/commands/{udid}").Handler(httptransport.NewServer(
+		e.NewRawCommandEndpoint,
+		decodeNewRawCommandRequest,
 		httputil.EncodeJSONResponse,
 		options...,
 	))

--- a/platform/command/server.go
+++ b/platform/command/server.go
@@ -39,7 +39,7 @@ func RegisterHTTPHandlers(r *mux.Router, e Endpoints, options ...httptransport.S
 	))
 
 	// DELETE     /v1/commands/udid		Clear device queue.
-	r.Methods("POST").Path("/v1/commands/{udid}").Handler(httptransport.NewServer(
+	r.Methods("DELETE").Path("/v1/commands/{udid}").Handler(httptransport.NewServer(
 		e.ClearQueueEndpoint,
 		decodeClearRequest,
 		httputil.EncodeJSONResponse,

--- a/platform/command/service.go
+++ b/platform/command/service.go
@@ -9,6 +9,7 @@ import (
 
 type Service interface {
 	NewCommand(context.Context, *mdm.CommandRequest) (*mdm.CommandPayload, error)
+	NewRawCommand(context.Context, *RawCommand) error
 }
 
 type CommandService struct {

--- a/platform/command/service.go
+++ b/platform/command/service.go
@@ -2,6 +2,7 @@
 package command
 
 import (
+	mdmsvc "github.com/micromdm/micromdm/mdm"
 	"github.com/micromdm/micromdm/mdm/mdm"
 	"github.com/micromdm/micromdm/platform/pubsub"
 	"golang.org/x/net/context"
@@ -10,15 +11,23 @@ import (
 type Service interface {
 	NewCommand(context.Context, *mdm.CommandRequest) (*mdm.CommandPayload, error)
 	NewRawCommand(context.Context, *RawCommand) error
+	ClearQueue(ctx context.Context, udid string) error
+}
+
+// Queue is an MDM Command Queue.
+type Queue interface {
+	Clear(context.Context, mdmsvc.CheckinEvent) error
 }
 
 type CommandService struct {
 	publisher pubsub.Publisher
+	queue     Queue
 }
 
-func New(pub pubsub.Publisher) (*CommandService, error) {
+func New(pub pubsub.Publisher, queue Queue) (*CommandService, error) {
 	svc := CommandService{
 		publisher: pub,
+		queue:     queue,
 	}
 	return &svc, nil
 }

--- a/tools/api/clear_queue
+++ b/tools/api/clear_queue
@@ -1,0 +1,5 @@
+#!/bin/bash
+source $MICROMDM_ENV_PATH
+endpoint="v1/commands/$1"
+
+curl $CURL_OPTS -K <(cat <<< "-u micromdm:$API_TOKEN") -X DELETE "$SERVER_URL/$endpoint" 

--- a/tools/api/raw_command
+++ b/tools/api/raw_command
@@ -1,0 +1,6 @@
+#!/bin/bash
+# raw_cmd $udid $path/to/cmd.plist
+source $MICROMDM_ENV_PATH
+endpoint="v1/commands/$1"
+
+curl $CURL_OPTS -K <(cat <<< "-u micromdm:$API_TOKEN") --data "@$2" "$SERVER_URL/$endpoint" 


### PR DESCRIPTION
Following discussions on the recent office hours, this PR adds support for enqueuing raw plist commands. This PR also adds an endpoint to clear command queues, since a malformed command could break a command queue. Without a way to clear a device's queue, a command queue could become unfixable, short of manually editing the database.

Here's a summary of the changes:

**Raw Command Enqueuing**

* Add POST /v1/command/{udid} endpoint
  * The request body is just the raw command plist
  * This is similar to NanoMDM's command enqueuing endpoint, though it doesn't currently support multiple ids
* Internally, this is published to a new `command.RawCommandTopic`, which the boltdb and inmem queues have new pollers for
 
**Clear Device Queue**

* Add DELETE /v1/command/{udid} endpoint
* This uses the existing `queue.Clear` method used during enrollment
* Internally, this couples the Command service with the command queue, as opposed to using the pubsub, but there is precedent with the command queue being coupled to the MDM service
  * I think this is acceptable since this endpoint should be used sparingly

**Note:** the code is complete, but I've marked as WIP since I haven't tested it yet.