### PR TITLE
adding a script to install VPP apps

### DIFF
--- a/tools/api/commands/install_vpp_application
+++ b/tools/api/commands/install_vpp_application
@@ -1,0 +1,15 @@
+#!/bin/bash  
+source $MICROMDM_ENV_PATH
+endpoint="v1/commands"
+jq -n \
+  --arg request_type "InstallApplication" \
+  --arg udid "$1" \
+  --arg itunes_store_id $2 \
+  '.udid = $udid
+  |.request_type = $request_type
+  |.itunes_store_id = ($itunes_store_id|tonumber)
+  |.options = {"purchase_method": 1}
+  '|\
+  curl $CURL_OPTS \
+    -H "Content-Type: application/json" \
+    -K <(cat <<< "-u micromdm:$API_TOKEN") "$SERVER_URL/$endpoint" -d@-


### PR DESCRIPTION
Installing VPP apps require a different format than install_appstore_application. itunes_store_id (as number ) is used instead of identifier. purchase_method option is also required. 