### PR TITLE
Address issues with /mdm/checkin endpoint

### DIFF
--- a/mdm/server.go
+++ b/mdm/server.go
@@ -138,8 +138,7 @@ func encodeResponse(ctx context.Context, w http.ResponseWriter, response interfa
 	}
 
 	if e, ok := response.(failer); ok && e.Failed() != nil {
-		encodeError(ctx, e.Failed(), w)
-		return nil
+		return e.Failed()
 	}
 
 	w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
This PR is to address some issues discovered while [troubleshooting enrollment issues](https://macadmins.slack.com/archives/C19RTE0L9/p1679701827459239) on the MacAdmins Slack:

* The device cert pkcs7 verification currently used on the /mdm/checkin doesn't account for time skew
  * Since the device is generating the certificate on the fly, if the device is just a few seconds ahead of the server, the server current time will be outside of the certificate validity, and verification will fail
  * This is fixed by adding a 5 minute skew with [VerifyWithChainAtTime](https://pkg.go.dev/go.mozilla.org/pkcs7#PKCS7.VerifyWithChainAtTime)
* Most of the errors in the mdm Endpoints are silently dropped because the response encoder called the error encoder directly, instead of just returning the error so it would pass back through the error logger.
  * This is fixed by making the response encoder returning errors.