### PR TITLE
add flag to include timestamp in logs

### DIFF
--- a/cmd/micromdm/serve.go
+++ b/cmd/micromdm/serve.go
@@ -126,6 +126,7 @@ func serve(args []string) error {
 		flPrintArgs              = flagset.Bool("print-flags", false, "Print all flags and their values")
 		flQueue                  = flagset.String("queue", env.String("MICROMDM_QUEUE", "builtin"), "command queue type")
 		flDMURL                  = flagset.String("dm", env.String("DM", ""), "URL to send Declarative Management requests to")
+		flLogTime                = flagset.Bool("log-time", false, "Include timestamp in log messages")
 	)
 	flagset.Usage = usageFor(flagset, "micromdm serve [flags]")
 	if err := flagset.Parse(args); err != nil {
@@ -154,6 +155,9 @@ func serve(args []string) error {
 	}
 
 	logger := log.NewLogfmtLogger(os.Stderr)
+	if *flLogTime {
+		logger = log.With(logger, "ts", log.DefaultTimestampUTC)
+	}
 	stdlog.SetOutput(log.NewStdlibAdapter(logger)) // force structured logs
 	mainLogger := log.With(logger, "component", "main")
 	mainLogger.Log("msg", "started")


### PR DESCRIPTION
There currently doesn't appear to be a way to have MicroMDM include a timestamp in it's logs. This PR adds a flag (default off) that will set the "ts" log key to the UTC timestamp.