### PR TITLE
Chore: tidy for go 1.20

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build, test, and format
     strategy:
       matrix:
-        go-version: [1.16.x, 1.17.x, 1.20.x]
+        go-version: [1.18.x, 1.19.x, 1.20.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build, test, and format
     strategy:
       matrix:
-        go-version: [1.16.x, 1.17.x]
+        go-version: [1.16.x, 1.17.x, 1.20.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## [Unreleased](https://github.com/micromdm/micromdm/compare/v1.11.0...main)
 
+- Add `-log-time` flag to include timestamps in log messages (#890)
+- Add `-device-signature-skew` flag to allow configuring clock skew when verifying device signatures (#887)
+- Tidy code for Go 1.20, and update Go version for Docker and CI
+- Project dependency updates (#888, #889, #900)
+
+Thanks to our contributors: @jamesez, @korylprince
+
 ## [v1.11.0](https://github.com/micromdm/micromdm/compare/v1.10.1...v1.11.0)
 
 This release includes new features and fixes.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17 as builder
+FROM golang:1.20 as builder
 
 WORKDIR /go/src/github.com/micromdm/micromdm/
 

--- a/cmd/mdmctl/apply.go
+++ b/cmd/mdmctl/apply.go
@@ -98,9 +98,7 @@ Examples:
   mdmctl apply blueprints -f /path/to/blueprint.json
 
   # Apply a DEP Profile.
-  mdmctl apply dep-profiles -f /path/to/dep-profile.json
-
-`
+  mdmctl apply dep-profiles -f /path/to/dep-profile.json`
 	fmt.Println(applyUsage)
 	return nil
 }
@@ -296,8 +294,8 @@ func (cmd *applyCommand) applyProfile(args []string) error {
 	)
 	flagset.Usage = func() {
 		fmt.Fprintf(os.Stderr, "%s\n",
-			`Upload profiles to the server. 
-			
+			`Upload profiles to the server.
+
 Uploaded profiles can also be specified in a blueprint, which will be applied on device enrollment.
 This command can also be used to replace the enrollment profile.
 Profiles can be signed before upload.

--- a/cmd/mdmctl/apply.go
+++ b/cmd/mdmctl/apply.go
@@ -98,8 +98,10 @@ Examples:
   mdmctl apply blueprints -f /path/to/blueprint.json
 
   # Apply a DEP Profile.
-  mdmctl apply dep-profiles -f /path/to/dep-profile.json`
-	fmt.Println(applyUsage)
+  mdmctl apply dep-profiles -f /path/to/dep-profile.json
+
+`
+	fmt.Print(applyUsage)
 	return nil
 }
 

--- a/cmd/mdmctl/apply.go
+++ b/cmd/mdmctl/apply.go
@@ -100,6 +100,7 @@ Examples:
   # Apply a DEP Profile.
   mdmctl apply dep-profiles -f /path/to/dep-profile.json
 
+
 `
 	fmt.Print(applyUsage)
 	return nil

--- a/cmd/mdmctl/apply_dep_autoassigner.go
+++ b/cmd/mdmctl/apply_dep_autoassigner.go
@@ -24,7 +24,7 @@ func (cmd *applyCommand) applyDEPAutoAssigner(args []string) error {
 		return errors.New("bad input: must provide both -filter and -uuid")
 	}
 
-	assigner := sync.AutoAssigner{*flFilter, *flProfileUUID}
+	assigner := sync.AutoAssigner{Filter: *flFilter, ProfileUUID: *flProfileUUID}
 
 	err := cmd.depsyncsvc.ApplyAutoAssigner(context.TODO(), &assigner)
 	if err != nil {

--- a/cmd/mdmctl/config.go
+++ b/cmd/mdmctl/config.go
@@ -78,8 +78,9 @@ func (cmd *configCommand) Usage() error {
 	const help = `
 mdmctl config print
 mdmctl config set -h
-mdmctl config switch -h`
-	fmt.Println(help)
+mdmctl config switch -h
+`
+	fmt.Print(help)
 	return nil
 }
 

--- a/cmd/mdmctl/config.go
+++ b/cmd/mdmctl/config.go
@@ -78,8 +78,7 @@ func (cmd *configCommand) Usage() error {
 	const help = `
 mdmctl config print
 mdmctl config set -h
-mdmctl config switch -h
-`
+mdmctl config switch -h`
 	fmt.Println(help)
 	return nil
 }

--- a/cmd/mdmctl/config.go
+++ b/cmd/mdmctl/config.go
@@ -79,6 +79,7 @@ func (cmd *configCommand) Usage() error {
 mdmctl config print
 mdmctl config set -h
 mdmctl config switch -h
+
 `
 	fmt.Print(help)
 	return nil

--- a/cmd/mdmctl/config.go
+++ b/cmd/mdmctl/config.go
@@ -117,7 +117,7 @@ func migrateServerConfig(configName string) error {
 	}
 	err = switchServerConfig(configName)
 	if err != nil {
-		err = fmt.Errorf("Failed to set %s as active config", configName)
+		err = fmt.Errorf("failed to set %s as active config", configName)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to set %s as active config", configName)
 		}
@@ -308,8 +308,7 @@ func LoadServerConfig() (*ServerConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	var serverCfg ServerConfig
-	serverCfg = cfg.Servers[cfg.Active]
+	var serverCfg ServerConfig = cfg.Servers[cfg.Active]
 	return &serverCfg, nil
 }
 

--- a/cmd/mdmctl/config.go
+++ b/cmd/mdmctl/config.go
@@ -107,7 +107,7 @@ func migrateServerConfig(configName string) error {
 	var serverCfg *ServerConfig
 	err = json.Unmarshal(cfgData, &serverCfg)
 	if err != nil {
-		return errors.Wrapf(err, "failed to unmarshal %s", configPath)
+		return fmt.Errorf("failed to unmarshal %s: %w", configPath, err)
 	}
 	if err = saveServerConfig(serverCfg, configName); err != nil {
 		return err
@@ -115,13 +115,10 @@ func migrateServerConfig(configName string) error {
 	if err = os.Remove(configPath); err != nil {
 		return err
 	}
-	err = switchServerConfig(configName)
-	if err != nil {
-		err = fmt.Errorf("failed to set %s as active config", configName)
-		if err != nil {
-			return errors.Wrapf(err, "Failed to set %s as active config", configName)
-		}
+	if err = switchServerConfig(configName); err != nil {
+		return fmt.Errorf("failed to set %s as active config: %w", configName, err)
 	}
+
 	fmt.Println("Successfully migrated old config.")
 	return nil
 }

--- a/cmd/mdmctl/get.go
+++ b/cmd/mdmctl/get.go
@@ -102,8 +102,7 @@ Examples:
   mdmctl get devices
 
   # Get a device by serial (TODO implement filtering)
-  mdmctl get devices -serials=C02ABCDEF
-`
+  mdmctl get devices -serials=C02ABCDEF`
 	fmt.Println(getUsage)
 	return nil
 }

--- a/cmd/mdmctl/get.go
+++ b/cmd/mdmctl/get.go
@@ -102,8 +102,10 @@ Examples:
   mdmctl get devices
 
   # Get a device by serial (TODO implement filtering)
-  mdmctl get devices -serials=C02ABCDEF`
-	fmt.Println(getUsage)
+  mdmctl get devices -serials=C02ABCDEF
+
+`
+	fmt.Print(getUsage)
 	return nil
 }
 

--- a/cmd/mdmctl/get_dep_profiles.go
+++ b/cmd/mdmctl/get_dep_profiles.go
@@ -23,7 +23,9 @@ func (out *depProfilesTableOutput) BasicFooter() {
 const noUUIDText = `The DEP API does not support listing profiles.
 A UUID flag must be specified. To get currently assigned profile UUIDs run
 	mdmctl get dep-devices -serials=serial1,serial2,serial3
-The output of the dep-devices response will contain the profile UUIDs.`
+The output of the dep-devices response will contain the profile UUIDs.
+
+`
 
 func (cmd *getCommand) getDEPProfiles(args []string) error {
 	flagset := flag.NewFlagSet("dep-profiles", flag.ExitOnError)
@@ -37,7 +39,7 @@ func (cmd *getCommand) getDEPProfiles(args []string) error {
 	}
 
 	if *flUUID == "" {
-		fmt.Println(noUUIDText)
+		fmt.Printf(noUUIDText)
 		flagset.Usage()
 		os.Exit(1)
 	}

--- a/cmd/mdmctl/get_dep_profiles.go
+++ b/cmd/mdmctl/get_dep_profiles.go
@@ -20,11 +20,10 @@ func (out *depProfilesTableOutput) BasicFooter() {
 	out.w.Flush()
 }
 
-const noUUIDText = `The DEP API does not support listing profiles. 
+const noUUIDText = `The DEP API does not support listing profiles.
 A UUID flag must be specified. To get currently assigned profile UUIDs run
 	mdmctl get dep-devices -serials=serial1,serial2,serial3
-The output of the dep-devices response will contain the profile UUIDs.
-`
+The output of the dep-devices response will contain the profile UUIDs.`
 
 func (cmd *getCommand) getDEPProfiles(args []string) error {
 	flagset := flag.NewFlagSet("dep-profiles", flag.ExitOnError)

--- a/cmd/mdmctl/mdmcert.download.go
+++ b/cmd/mdmctl/mdmcert.download.go
@@ -70,9 +70,7 @@ need to decrypt the push certificate request:
 This will output the push certificate request to mdmcert.download.req.
 Upload this file to https://identity.apple.com and download the signed
 certificate. Then use the 'mdmctl mdmcert upload' command to upload it,
-(and the above private key) into MicroMDM.
-
-`
+(and the above private key) into MicroMDM.`
 	fmt.Println(usageText)
 	return nil
 

--- a/cmd/mdmctl/mdmcert.download.go
+++ b/cmd/mdmctl/mdmcert.download.go
@@ -72,6 +72,7 @@ Upload this file to https://identity.apple.com and download the signed
 certificate. Then use the 'mdmctl mdmcert upload' command to upload it,
 (and the above private key) into MicroMDM.
 
+
 `
 	fmt.Print(usageText)
 	return nil

--- a/cmd/mdmctl/mdmcert.download.go
+++ b/cmd/mdmctl/mdmcert.download.go
@@ -277,7 +277,7 @@ func sendMdmcertDownloadRequest(client *http.Client, req *http.Request) error {
 		return err
 	}
 	if jsn.Result != "success" {
-		return fmt.Errorf("got unexpected result body: %q\n", jsn.Result)
+		return fmt.Errorf("got unexpected result body: %q", jsn.Result)
 	}
 	return nil
 }

--- a/cmd/mdmctl/mdmcert.download.go
+++ b/cmd/mdmctl/mdmcert.download.go
@@ -70,8 +70,10 @@ need to decrypt the push certificate request:
 This will output the push certificate request to mdmcert.download.req.
 Upload this file to https://identity.apple.com and download the signed
 certificate. Then use the 'mdmctl mdmcert upload' command to upload it,
-(and the above private key) into MicroMDM.`
-	fmt.Println(usageText)
+(and the above private key) into MicroMDM.
+
+`
+	fmt.Print(usageText)
 	return nil
 
 }

--- a/cmd/mdmctl/mdmcert.go
+++ b/cmd/mdmctl/mdmcert.go
@@ -59,8 +59,7 @@ Use the push private key and the push cert you got from identity.apple.com in yo
 Commands:
     vendor
     push
-    upload
-`
+    upload`
 	fmt.Println(usageText)
 	return nil
 

--- a/cmd/mdmctl/mdmcert.go
+++ b/cmd/mdmctl/mdmcert.go
@@ -59,8 +59,10 @@ Use the push private key and the push cert you got from identity.apple.com in yo
 Commands:
     vendor
     push
-    upload`
-	fmt.Println(usageText)
+    upload
+
+`
+	fmt.Print(usageText)
 	return nil
 
 }

--- a/cmd/mdmctl/remove.go
+++ b/cmd/mdmctl/remove.go
@@ -68,8 +68,7 @@ Valid resource types:
   * devices
   * profiles
   * block
-  * dep-autoassigner
-`
+  * dep-autoassigner`
 
 	fmt.Println(getUsage)
 	return nil

--- a/cmd/mdmctl/remove.go
+++ b/cmd/mdmctl/remove.go
@@ -68,8 +68,10 @@ Valid resource types:
   * devices
   * profiles
   * block
-  * dep-autoassigner`
+  * dep-autoassigner
 
-	fmt.Println(getUsage)
+`
+
+	fmt.Print(getUsage)
 	return nil
 }


### PR DESCRIPTION
Go 1.20's `test` will fail mdmctl because of strings with trailing newlines. This PR removes the newlines, and adds 1.20 to the build matrix.

I also tidied three minor complaints from staticcheck.