### PR TITLE
updated to go-macos-pkg v1.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add support for inspecting the MDM command queue (#895)
   - See the [docs](https://github.com/micromdm/micromdm/blob/main/docs/user-guide/api-and-webhooks.md#inspecting-the-command-queue) for how to use
 - Fix HTTP status codes being swallowed by -http-debug flag (#906)
+- Fix pkg signature checks on non-macOS platforms (#930)
 - Project dependency updates (#888, #889, #900)
 
 Thanks to our contributors: @grahamgilbert, @jamesez, @korylprince

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/jessepeterson/cfgprofiles v0.3.0
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/kolide/kit v0.0.0-20180912215818-0c28f72eb2b0
-	github.com/korylprince/go-macos-pkg v1.3.5
+	github.com/korylprince/go-macos-pkg v1.3.6
 	github.com/lib/pq v1.2.0
 	github.com/micromdm/go4 v0.0.0-20230719210527-7c4a9b165b09
 	github.com/micromdm/scep/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/kolide/kit v0.0.0-20180912215818-0c28f72eb2b0 h1:8UB0NJBoB/lN2O9zG9+U
 github.com/kolide/kit v0.0.0-20180912215818-0c28f72eb2b0/go.mod h1:N3Yv8okDVC/5qZhPA9uxVYRfkp4mD2vrlQiSCWlNCpg=
 github.com/korylprince/go-cpio-odc v0.9.4 h1:N0Afrp7Z5qCZF8cbpzF5CvyiC/KHK5IcLJwqm5MWpNU=
 github.com/korylprince/go-cpio-odc v0.9.4/go.mod h1:1iHsjUXO64Hui0YsubGp0Tm/Uf04Iow2iy+1LJIarMw=
-github.com/korylprince/go-macos-pkg v1.3.5 h1:jwwefLR1yRKQPNu51QTwk2B4abIjjISj/BHipcvKKGs=
-github.com/korylprince/go-macos-pkg v1.3.5/go.mod h1:jlPGliXXjjCMpISR30/fL60hXKrCJ2LNQSptdx+WQkc=
+github.com/korylprince/go-macos-pkg v1.3.6 h1:dvAppt2qyiRJ4pOIIhXuJDiXpvtEjmETgbgquifLG4Y=
+github.com/korylprince/go-macos-pkg v1.3.6/go.mod h1:jlPGliXXjjCMpISR30/fL60hXKrCJ2LNQSptdx+WQkc=
 github.com/korylprince/goxar v0.0.0-20211111233330-e9f257bcdf25 h1:XVf+U+WekiGPPD27w7qI+0Pe8NehaTWPqRuO3BddefY=
 github.com/korylprince/goxar v0.0.0-20211111233330-e9f257bcdf25/go.mod h1:Lm6kfGMVHcpiBP6oOZd3ugv2EpQ/dOyW02tVIa3qo2Q=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 h1:T+h1c/A9Gawja4Y9mFVWj2vyii2bbUNDw3kt9VxK2EY=


### PR DESCRIPTION
(At least sometimes) Apple doesn't include the `signature-creation-time` field in the xar (pkg) TOC.

On non-darwin platforms, mdmctl uses [go-macos-pkg](https://github.com/korylprince/go-macos-pkg), which wraps [my fork of the goxar pkg](https://github.com/korylprince/goxar), to verify that pkgs are signed. goxar uses the presence of the `signature-creation-time` to determine if a pkg is signed, (despite already verifying the signature).

This PR updates go-macos-pkg to v1.3.6, which removes the check for `signature-creation-time`.