### PR TITLE
Allow disabling :80 to :443 redirect (Fixes #963)

### DIFF
--- a/cmd/micromdm/serve.go
+++ b/cmd/micromdm/serve.go
@@ -129,6 +129,7 @@ func serve(args []string) error {
 		flDMURL                  = flagset.String("dm", env.String("DM", ""), "URL to send Declarative Management requests to")
 		flLogTime                = flagset.Bool("log-time", false, "Include timestamp in log messages")
 		flP7Skew                 = flagset.Int("device-signature-skew", env.Int("MICROMDM_DEVICE_SIGNATURE_SKEW", 0), "Sets the allowable clock skew (in seconds) when verifying device signatures")
+		flDisableRedirect        = flagset.Bool("disable-redirect", env.Bool("MICROMDM_DISABLE_REDIRECT", false), "disable the :80 -> :443 redirect if listening on :443")
 	)
 	flagset.Usage = usageFor(flagset, "micromdm serve [flags]")
 	if err := flagset.Parse(args); err != nil {
@@ -363,6 +364,7 @@ func serve(args []string) error {
 		*flTLSKey,
 		sm.ConfigPath,
 		*flTLS,
+		*flDisableRedirect,
 	)
 	err = httputil.ListenAndServe(serveOpts...)
 	return errors.Wrap(err, "calling ListenAndServe")
@@ -378,6 +380,7 @@ func serveOptions(
 	keyPath string,
 	configPath string,
 	tls bool,
+	disableRedirect bool,
 ) []httputil.Option {
 	tlsFromFile := (certPath != "" && keyPath != "")
 	serveOpts := []httputil.Option{
@@ -396,6 +399,9 @@ func serveOptions(
 	}
 	if addr != ":https" {
 		serveOpts = append(serveOpts, httputil.WithAddress(addr))
+	}
+	if disableRedirect {
+		serveOpts = append(serveOpts, httputil.WithAllowRedirectHTTPS(false))
 	}
 	return serveOpts
 }

--- a/cmd/micromdm/serve.go
+++ b/cmd/micromdm/serve.go
@@ -401,7 +401,7 @@ func serveOptions(
 		serveOpts = append(serveOpts, httputil.WithAddress(addr))
 	}
 	if disableRedirect {
-		serveOpts = append(serveOpts, httputil.WithAllowRedirectHTTPS(false))
+		serveOpts = append(serveOpts, httputil.WithDisableRedirect(true))
 	}
 	return serveOpts
 }

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/kolide/kit v0.0.0-20180912215818-0c28f72eb2b0
 	github.com/korylprince/go-macos-pkg v1.3.6
 	github.com/lib/pq v1.10.9
-	github.com/micromdm/go4 v0.0.0-20230719210527-7c4a9b165b09
+	github.com/micromdm/go4 v0.0.0-20240215190618-908f27575419
 	github.com/micromdm/scep/v2 v2.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/smallstep/pkcs7 v0.0.0-20231107075624-be1870d87d13

--- a/go.sum
+++ b/go.sum
@@ -321,8 +321,8 @@ github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/
 github.com/mattn/go-sqlite3 v1.14.6 h1:dNPt6NO46WmLVt2DLNpwczCmdV5boIZ6g/tlDrlRUbg=
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/micromdm/go4 v0.0.0-20230719210527-7c4a9b165b09 h1:COW3H2j8Xcx1va6z8FwbwaegIviz33rWuAiyp4MVL8A=
-github.com/micromdm/go4 v0.0.0-20230719210527-7c4a9b165b09/go.mod h1:uZTekMktf1ayaNK9onByUXwKleUvJNQw/cpZaNkvvRo=
+github.com/micromdm/go4 v0.0.0-20240215190618-908f27575419 h1:vIJ+N4FitO3izetK3FJTQrjF3besjgWWvQMxtSdffZI=
+github.com/micromdm/go4 v0.0.0-20240215190618-908f27575419/go.mod h1:uZTekMktf1ayaNK9onByUXwKleUvJNQw/cpZaNkvvRo=
 github.com/micromdm/scep/v2 v2.2.0 h1:MO2vZl5dSyojC2KpN4ik3671ZjdZvM8lpxS/YukhIMs=
 github.com/micromdm/scep/v2 v2.2.0/go.mod h1:mEmykFaZklQfGZ1Dl9oRJOx/3fxvF2D1l+cDJokzDwk=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=


### PR DESCRIPTION
This PR adds a flag to allow disabling the :80 to :443 redirect. This PR is pending merge of https://github.com/micromdm/go4/pull/16 and updating go.mod/go.sum.