### PR TITLE
Add detection of buggy DEP cursors

### DIFF
--- a/platform/dep/sync/depsync.go
+++ b/platform/dep/sync/depsync.go
@@ -337,7 +337,16 @@ func (w *Watcher) Run() error {
 			}
 
 			if resp.MoreToFollow {
-				continue
+				if resp.Cursor != w.cursor.Value {
+					continue
+				}
+				level.Info(w.logger).Log(
+					"msg", "DEP returned the same cursor that was sent, exiting sync early",
+					"phase", fetchNextLabel[fetchNext],
+					"cursor", w.cursor.Value,
+					"fetched", resp.FetchedUntil,
+					"more", resp.MoreToFollow,
+				)
 			} else if fetchNext {
 				fetchNext = false
 				continue


### PR DESCRIPTION
Recently on the MacAdmins Slack @trekkim described an issue where the DEP syncer was syncing several times a second.

On [closer inspection](https://macadmins.slack.com/archives/C19RTE0L9/p1721587227194389?thread_ts=1721584429.406019&cid=C19RTE0L9), Apple's response to the fetch devices endpoint used the same cursor sent in the request, and set the `more_to_follow` field to true. This caused MicroMDM to make the same request over and over again in a tight loop.

Ultimately the fix was to delete the "bad" cursor out of the database and start a new sync.

Ideally, Apple would fix this behavior on their side. Until then, this PR adds detection (return same cursor and `more_to_follow`=true) and correction (fetch with an empty cursor) for this situation.