### PR TITLE
Fix #641: Unable to disable bluetooth

### DIFF
--- a/mdm/mdm/unmarshal_proto.go
+++ b/mdm/mdm/unmarshal_proto.go
@@ -414,7 +414,8 @@ func protoToSetting(s *mdmproto.Setting) Setting {
 		setting.Enabled = nilIfFalse(pbs.GetEnabled())
 	case "Bluetooth":
 		pbs := s.GetBluetooth()
-		setting.Enabled = nilIfFalse(pbs.GetEnabled())
+		setting.Enabled = new(bool)
+		*setting.Enabled = pbs.GetEnabled()
 	case "ApplicationAttributes":
 		pbs := s.GetApplicationAttributes()
 		attr := pbs.GetApplicationAttributes()


### PR DESCRIPTION
Current behaviour:
The Settings payload works for enabling bluetooth on the device, but it fails to disable it.
```
{ "request_type": "Settings", "udid": "<uid>", "Settings": [
    { "Item": "Bluetooth", "Enabled": true }
]}
```

As mentioned in the issue #641, the nil values are omitted while serialising the payload into plist.
This PR removes conversion of `false` to nil value.