### PR TITLE
Dynamically parameterise micromdm config file from hit URL

### DIFF
--- a/cmd/micromdm/serve.go
+++ b/cmd/micromdm/serve.go
@@ -81,6 +81,21 @@ body {
   text-decoration: none;
 }
   </style>
+  <script>
+    window.onload = function() {
+      const urlParams = new URLSearchParams(window.location.search);
+      const enrollLink = document.getElementById('enroll-link');      
+      const queryParams = new URLSearchParams();
+      for (const [key, value] of urlParams.entries()) {
+        if (value) {
+          queryParams.set(key, value);
+        }
+      }
+      if (queryParams.toString()) {
+        enrollLink.href = 'mdm/enroll?' + queryParams.toString();
+      }
+    };
+  </script>
  </head>
 <body>
 
@@ -94,7 +109,7 @@ body {
 </svg>
 
 
-<p><a class=enrollment href="mdm/enroll">Enroll a device</a></p>
+<p><a id="enroll-link" class=enrollment href="mdm/enroll">Enroll a device</a></p>
 
 </body>
 </html>

--- a/mdm/enroll/endpoint.go
+++ b/mdm/enroll/endpoint.go
@@ -47,7 +47,9 @@ type otaEnrollmentRequest struct {
 	UserShortName string
 }
 
-type mdmEnrollRequest struct{}
+type mdmEnrollRequest struct {
+	QueryParams map[string]string
+}
 
 type mobileconfigResponse struct {
 	profile.Mobileconfig
@@ -71,11 +73,11 @@ func MakeGetEnrollEndpoint(s Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		switch req := request.(type) {
 		case mdmEnrollRequest:
-			mc, err := s.Enroll(ctx)
+			mc, err := s.Enroll(ctx, req.QueryParams)
 			return mobileconfigResponse{mc, err}, nil
 		case depEnrollmentRequest:
 			fmt.Printf("got DEP enrollment request from %s\n", req.Serial)
-			mc, err := s.Enroll(ctx)
+			mc, err := s.Enroll(ctx, make(map[string]string))
 			return mobileconfigResponse{mc, err}, nil
 		default:
 			return nil, errors.New("unknown enrollment type")
@@ -133,7 +135,7 @@ func MakeOTAPhase2Phase3Endpoint(s Service, scepDepot depot.Depot) endpoint.Endp
 			// TODO: the SCEP CA checking ought to be more robust
 			// see: https://github.com/micromdm/scep/issues/32
 
-			mc, err := s.Enroll(ctx)
+			mc, err := s.Enroll(ctx, make(map[string]string))
 			// profile, err := s.OTAPhase3(ctx)
 			return mobileconfigResponse{mc, err}, nil
 		}

--- a/mdm/enroll/profile_test.go
+++ b/mdm/enroll/profile_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestEnrollProfile(t *testing.T) {
 	svc := new(service)
-	profile, err := svc.MakeEnrollmentProfile()
+	profile, err := svc.MakeEnrollmentProfile("")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/mdm/enroll/service.go
+++ b/mdm/enroll/service.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"io/ioutil"
 	"log"
+	"net/url"
 	"strings"
 	"sync"
 
@@ -36,7 +37,7 @@ const (
 )
 
 type Service interface {
-	Enroll(ctx context.Context) (profile.Mobileconfig, error)
+	Enroll(ctx context.Context, queryParams map[string]string) (profile.Mobileconfig, error)
 	OTAEnroll(ctx context.Context) (profile.Mobileconfig, error)
 	OTAPhase2(ctx context.Context) (profile.Mobileconfig, error)
 	OTAPhase3(ctx context.Context) (profile.Mobileconfig, error)
@@ -175,8 +176,10 @@ func (svc *service) findOrMakeMobileconfig(ctx context.Context, id string, f int
 	return p.Mobileconfig, nil
 }
 
-func (svc *service) Enroll(ctx context.Context) (profile.Mobileconfig, error) {
-	return svc.findOrMakeMobileconfig(ctx, EnrollmentProfileId, svc.MakeEnrollmentProfile)
+func (svc *service) Enroll(ctx context.Context, queryParams map[string]string) (profile.Mobileconfig, error) {
+	return svc.findOrMakeMobileconfig(ctx, EnrollmentProfileId, func() (*cfgprofiles.Profile, error) {
+		return svc.MakeEnrollmentProfile(queryParams)
+	})
 }
 
 func (svc *service) scepChallenge() (challenge string, err error) {
@@ -191,7 +194,7 @@ func (svc *service) scepChallenge() (challenge string, err error) {
 const perUserConnections = "com.apple.mdm.per-user-connections"
 const bootstrapToken = "com.apple.mdm.bootstraptoken"
 
-func (svc *service) MakeEnrollmentProfile() (*cfgprofiles.Profile, error) {
+func (svc *service) MakeEnrollmentProfile(queryParams map[string]string) (*cfgprofiles.Profile, error) {
 	profile := cfgprofiles.NewProfile(EnrollmentProfileId)
 	profile.PayloadOrganization = profilePayloadOrganization
 	profile.PayloadDisplayName = profilePayloadDisplayName
@@ -202,7 +205,21 @@ func (svc *service) MakeEnrollmentProfile() (*cfgprofiles.Profile, error) {
 	mdmPayload.PayloadDescription = mdmPayloadDescription
 
 	mdmPayload.ServerURL = svc.URL + mdmPayloadServerEndpoint
-	mdmPayload.CheckInURL = svc.URL + mdmPayloadCheckInEndpoint
+
+	// Build query string from parameters with proper URL encoding
+	checkInURL := svc.URL + mdmPayloadCheckInEndpoint
+	if len(queryParams) > 0 {
+		values := url.Values{}
+		for key, value := range queryParams {
+			if value != "" {
+				values.Set(key, value)
+			}
+		}
+		if len(values) > 0 {
+			checkInURL += "?" + values.Encode()
+		}
+	}
+	mdmPayload.CheckInURL = checkInURL
 	mdmPayload.CheckOutWhenRemoved = true
 	mdmPayload.AccessRights = 8191
 

--- a/mdm/enroll/transport_http.go
+++ b/mdm/enroll/transport_http.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"html"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 
 	"github.com/micromdm/micromdm/pkg/crypto"
 
@@ -59,7 +61,20 @@ type verifier struct {
 func (v verifier) decodeMDMEnrollRequest(_ context.Context, r *http.Request) (interface{}, error) {
 	switch r.Method {
 	case "GET":
-		return mdmEnrollRequest{}, nil
+		queryParams := make(map[string]string)
+		decodedQuery := html.UnescapeString(r.URL.RawQuery)
+		if decodedQuery != "" {
+			parsedQuery, err := url.ParseQuery(decodedQuery)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse query string: %w", err)
+			}
+			for key, values := range parsedQuery {
+				if len(values) > 0 {
+					queryParams[key] = values[0]
+				}
+			}
+		}
+		return mdmEnrollRequest{QueryParams: queryParams}, nil
 	case "POST": // DEP request
 		data, err := ioutil.ReadAll(r.Body)
 		if err != nil {


### PR DESCRIPTION
Addressing the issue https://github.com/micromdm/micromdm/issues/1102 of not being able to send query parameters to webhook on profile basis.


I'm suggesting a way where anyone wants to create custom enrolment `.mobileconfig` files based on `mdm/enroll?key=value`, it would automatically create those `.mobileconfig` files by fetching `key=value` params.

Webhook can receive this information from check-in URL

Hope this helps !