### PR TITLE
Add opt-in -migration flag support for micromdm migration endpoint

### DIFF
--- a/cmd/micromdm/serve.go
+++ b/cmd/micromdm/serve.go
@@ -130,6 +130,7 @@ func serve(args []string) error {
 		flLogTime                = flagset.Bool("log-time", false, "Include timestamp in log messages")
 		flP7Skew                 = flagset.Int("device-signature-skew", env.Int("MICROMDM_DEVICE_SIGNATURE_SKEW", 0), "Sets the allowable clock skew (in seconds) when verifying device signatures")
 		flDisableRedirect        = flagset.Bool("disable-redirect", env.Bool("MICROMDM_DISABLE_REDIRECT", false), "disable the :80 -> :443 redirect if listening on :443")
+		flMigration              = flagset.Bool("migration", env.Bool("MICROMDM_MIGRATION", false), "enable the Basic-Auth /mdm/migration-checkin endpoint for NanoMDM migration dual-write (skips device signature verification)")
 	)
 	flagset.Usage = usageFor(flagset, "micromdm serve [flags]")
 	if err := flagset.Parse(args); err != nil {
@@ -328,6 +329,10 @@ func serve(args []string) error {
 		}
 
 		r.HandleFunc("/boltbackup", httputil2.RequireBasicAuth(boltBackup(sm.DB), "micromdm", *flAPIKey, "micromdm"))
+
+		if *flMigration {
+			mdm.RegisterMigrationSyncHandler(r, sm.PubClient, "micromdm", *flAPIKey)
+		}
 	} else {
 		mainLogger.Log("msg", "no api key specified")
 	}

--- a/mdm/migration_sync.go
+++ b/mdm/migration_sync.go
@@ -1,0 +1,65 @@
+package mdm
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+	"github.com/micromdm/micromdm/pkg/httputil"
+	"github.com/micromdm/micromdm/platform/pubsub"
+	"github.com/pkg/errors"
+)
+
+// RegisterMigrationSyncHandler registers a Basic-Auth-protected endpoint that publishes a
+// checkin event directly onto the pubsub bus, bypassing both Mdm-Signature verification and
+// the cert-auth middleware around the real Service.Checkin path (which panics on a missing
+// device cert — one this route never has).
+//
+// It exists only for the NanoMDM migration: a dual-writer (mdmdirector) mirrors
+// Authenticate/TokenUpdate/CheckOut events from NanoMDM into this MicroMDM's device store
+// (via the same workers a real checkin feeds), keeping it fresh as a rollback target.
+// Gated behind the -migration flag
+func RegisterMigrationSyncHandler(r *mux.Router, pub pubsub.Publisher, username, apiKey string) {
+	r.Methods(http.MethodPut).Path("/mdm/migration-checkin").Handler(
+		httputil.RequireBasicAuth(migrationCheckinHandler(pub), username, apiKey, "micromdm"),
+	)
+}
+
+func migrationCheckinHandler(pub pubsub.Publisher) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var cmd CheckinCommand
+		body, err := mdmRequestBody(r, &cmd)
+		if err != nil {
+			http.Error(w, errors.Wrap(err, "read migration-checkin body").Error(), http.StatusBadRequest)
+			return
+		}
+
+		event := CheckinEvent{
+			ID:      uuid.New().String(),
+			Time:    time.Now().UTC(),
+			Command: cmd,
+			Raw:     body,
+		}
+
+		msg, err := MarshalCheckinEvent(&event)
+		if err != nil {
+			http.Error(w, errors.Wrap(err, "marshal migration checkin event").Error(), http.StatusInternalServerError)
+			return
+		}
+
+		topic, err := topicFromMessage(cmd.MessageType)
+		if err != nil {
+			http.Error(w, errors.Wrap(err, "get migration checkin topic").Error(), http.StatusBadRequest)
+			return
+		}
+
+		if err := pub.Publish(context.Background(), topic, msg); err != nil {
+			http.Error(w, errors.Wrap(err, "publish migration checkin").Error(), http.StatusInternalServerError)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}
+}


### PR DESCRIPTION
## What

Wires up the new micromdm `-migration` server flag (added in micromdm
`Add migration sync endpoint`) so it can be toggled per environment from Chef.

When enabled, micromdm exposes the Basic-Auth `/mdm/migration-checkin`
endpoint used for NanoMDM migration dual-write: a dual-writer (mdmdirector)
mirrors Authenticate/TokenUpdate/CheckOut events from NanoMDM into this
MicroMDM's device store, keeping it fresh as a rollback target.